### PR TITLE
Bug in boundary checking in the CBORParser

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -2265,11 +2265,11 @@ public final class CBORParser extends ParserMinimalBase
             int inPtr = _inputPtr;
             final byte[] inBuf = _inputBuffer;
             int q = inBuf[inPtr] & 0xFF;
-            if (len > 0) {
+            if (len > 1) {
                 q = (q << 8) + (inBuf[++inPtr] & 0xFF);
-                if (len > 1) {
+                if (len > 2) {
                     q = (q << 8) + (inBuf[++inPtr] & 0xFF);
-                    if (len > 2) {
+                    if (len > 3) {
                         q = (q << 8) + (inBuf[++inPtr] & 0xFF);
                     }
                 }

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/ParserInputStreamTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/ParserInputStreamTest.java
@@ -1,0 +1,54 @@
+package com.fasterxml.jackson.dataformat.cbor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.SequenceInputStream;
+
+public class ParserInputStreamTest extends CBORTestBase {
+
+    @Test
+    public void testInpuStream() throws Exception {
+        CBORFactory f = new CBORFactory();
+        ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
+        byte[] buffer = generateHugeCBOR(f);
+
+        // split the buffer in two smaller buffer
+        int len = 160;
+        byte[] buf1 = new byte[len];
+        byte[] buf2 = new byte[buffer.length - len];
+        System.arraycopy(buffer, 0, buf1, 0, len);
+        System.arraycopy(buffer, len, buf2, 0, buffer.length - len);
+
+        // aggregate the two buffers via a SequenceInputStream
+        ByteArrayInputStream in1 = new ByteArrayInputStream(buf1);
+        ByteArrayInputStream in2 = new ByteArrayInputStream(buf2);
+        SequenceInputStream inputStream = new SequenceInputStream(in1, in2);
+
+        try {
+            JsonNode jsonNode = cborMapper.readTree(inputStream);
+        }
+        catch (ArrayIndexOutOfBoundsException ex){
+            ex.printStackTrace();
+            fail("Shouldn't throw an ArrayIndexOutOfBoundsException while parsing!");
+        }
+    }
+
+    private byte[] generateHugeCBOR(CBORFactory f) throws IOException {
+        String hugeJson = "{";
+        for (char c='a'; c <= 'z'; c++) {
+            for (char cc='a'; cc <= 'z'; cc++) {
+                hugeJson += "\"" + c + cc + "\":0,";
+            }
+            for (int i = 0; i < 50; i++) {
+                hugeJson += "\"" + c + i + "\":" + i + ",";
+            }
+        }
+        hugeJson += "\"name\":123";
+        hugeJson += "}";
+        return cborDoc(f, hugeJson);
+    }
+}


### PR DESCRIPTION
When reading from an composite inputStream, there's a bug during the checking
of the buffer boundary. This may lead to an ArrayIndexOutOfBoundsException.

I build a test case that expose the bug and fixed the bound checking.