### PR TITLE
Specialise copyCurrentStructue() and copyCurrentEvent() to respect tags.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
@@ -1411,5 +1411,39 @@ public class CBORGenerator extends GeneratorBase
 
     protected UnsupportedOperationException _notSupported() {
         return new UnsupportedOperationException();
-    }    
+    }
+
+    /**
+     * Specialise {@link JsonGenerator#copyCurrentEvent} to handle tags.
+     */
+    @Override
+    public void copyCurrentEvent(JsonParser jp) throws IOException {
+        maybeCopyTag(jp);
+        super.copyCurrentEvent(jp);
+    }
+
+    /**
+     * Specialise {@link JsonGenerator#copyCurrentStructure} to handle tags.
+     */
+    @Override
+    public void copyCurrentStructure(JsonParser jp) throws IOException {
+        maybeCopyTag(jp);
+        super.copyCurrentStructure(jp);
+    }
+
+    private void maybeCopyTag(JsonParser jp) throws IOException {
+        final JsonToken t = jp.getCurrentToken();
+
+        if (t == null || t == JsonToken.NOT_AVAILABLE) {
+            _reportError("No current event to copy");
+        }
+
+        if (jp instanceof CBORParser) {
+            final int currentTag = ((CBORParser)jp).getCurrentTag();
+
+            if (currentTag != -1) {
+                writeTag(currentTag);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #22.