### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
@@ -559,6 +559,18 @@ public class CBORGenerator extends GeneratorBase
         }        
     }
 
+    /*@Override // since 2.8
+    public final void writeStartObject(Object forValue) throws IOException
+    {
+        _verifyValueWrite("start an object");
+        JsonWriteContext ctxt = _writeContext.createChildObjectContext();
+        _writeContext = ctxt;
+        if (forValue != null) {
+            ctxt.setCurrentValue(forValue);
+        }
+        _writeByte(BYTE_OBJECT_INDEFINITE);
+    }*/
+
     @Override
     public final void writeEndObject() throws IOException
     {

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.dataformat.cbor;
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Stack;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.*;
@@ -489,15 +490,14 @@ public class CBORGenerator extends GeneratorBase
     /**********************************************************
      */
 
+    Stack<Integer> _arraySize = new Stack<Integer>();
+    
     @Override
     public final void writeStartArray() throws IOException
     {
-        _verifyValueWrite("start an array");
-        _writeContext = _writeContext.createChildArrayContext();
-        _writeByte(BYTE_ARRAY_INDEFINITE);
+    	writeStartArray(-1);
     }
 
-    // TODO: implement this for CBOR
     /*
      * Unlike with JSON, this method can use slightly optimized version
      * since CBOR has a variant that allows embedding length in array
@@ -509,43 +509,54 @@ public class CBORGenerator extends GeneratorBase
     public void writeStartArray(int size) throws IOException {
         _verifyValueWrite("start an array");
         _writeContext = _writeContext.createChildArrayContext();
-        /*
-        if (size >= 31 || size < 0) {
-            _writeByte(BYTE_ARRAY_INDEFINITE);
+        
+        _arraySize.push(size);
+        
+        if (size < 0 || size >= 31) {
+          
+          _writeByte(BYTE_ARRAY_INDEFINITE);
         } else {
+        
+          _writeByte((byte)(PREFIX_TYPE_ARRAY + size));
         }
-        */
-        _writeByte(BYTE_ARRAY_INDEFINITE);
     }
-
+    
     @Override
     public final void writeEndArray() throws IOException
     {
         if (!_writeContext.inArray()) {
             _reportError("Current context not an ARRAY but "+_writeContext.getTypeDesc());
         }
-        _writeByte(BYTE_BREAK);
+        
+        int size = _arraySize.pop();
+        if (size < 0 || size >= 31) {
+            _writeByte(BYTE_BREAK); 
+        }
         _writeContext = _writeContext.getParent();
     }
 
+    Stack<Integer> _objectSize = new Stack<Integer>();
+    
     @Override
     public final void writeStartObject() throws IOException
     {
-        _verifyValueWrite("start an object");
-        _writeContext = _writeContext.createChildObjectContext();
-        _writeByte(BYTE_OBJECT_INDEFINITE);
+    	writeStartObject(-1);       
     }
-
-    @Override // since 2.8
-    public final void writeStartObject(Object forValue) throws IOException
+    
+    public void writeStartObject(int size) throws IOException
     {
         _verifyValueWrite("start an object");
-        JsonWriteContext ctxt = _writeContext.createChildObjectContext();
-        _writeContext = ctxt;
-        if (forValue != null) {
-            ctxt.setCurrentValue(forValue);
-        }
-        _writeByte(BYTE_OBJECT_INDEFINITE);
+        _writeContext = _writeContext.createChildObjectContext();
+        
+        _objectSize.push(size);
+
+        if (size < 0 || size >= 31) {
+          
+          _writeByte(BYTE_OBJECT_INDEFINITE);
+        } else {
+        
+          _writeByte((byte)(PREFIX_TYPE_OBJECT + size));
+        }        
     }
 
     @Override
@@ -555,7 +566,11 @@ public class CBORGenerator extends GeneratorBase
             _reportError("Current context not an object but "+_writeContext.getTypeDesc());
         }
         _writeContext = _writeContext.getParent();
-        _writeByte(BYTE_BREAK);
+        
+        int size = _objectSize.pop();
+        if (size < 0 || size >= 31) {
+          _writeByte(BYTE_BREAK); 
+        }
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
@@ -559,17 +559,18 @@ public class CBORGenerator extends GeneratorBase
         }        
     }
 
-    /*@Override // since 2.8
-    public final void writeStartObject(Object forValue) throws IOException
-    {
+    @Override // since 2.8
+    public final void writeStartObject(Object forValue) throws IOException {
         _verifyValueWrite("start an object");
         JsonWriteContext ctxt = _writeContext.createChildObjectContext();
         _writeContext = ctxt;
         if (forValue != null) {
             ctxt.setCurrentValue(forValue);
         }
+
+        _objectSize.push(-1);
         _writeByte(BYTE_OBJECT_INDEFINITE);
-    }*/
+    }
 
     @Override
     public final void writeEndObject() throws IOException

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -833,17 +833,19 @@ public final class CBORParser extends ParserMinimalBase
         }
         throw _constructError("Invalid CBOR value token (first byte): 0x"+Integer.toHexString(ch));
     }
+
     /**
      * Method for forcing full read of current token, even if it might otherwise
      * only be read if data is accessed via {@link #getText} and similar methods.
      */
+    @Override
     public void finishToken() throws IOException
     {
         if (_tokenIncomplete) {
             _finishToken();
         }
     }
-    
+
     /*
     /**********************************************************
     /* Public API, traversal, nextXxxValue/nextFieldName

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -823,6 +823,19 @@ public final class CBORParser extends ParserMinimalBase
         return String.valueOf(1);
     }
 
+    // @since 2.7.2 -- will be added in `JsonParser` in 2.8
+    // see [dataformat-cbor#20]
+    /**
+     * Method for forcing full read of current token, even if it might otherwise
+     * only be read if data is accessed via {@link #getText} and similar methods.
+     */
+    public void finishToken() throws IOException
+    {
+        if (_tokenIncomplete) {
+            _finishToken();
+        }
+    }
+    
     // base impl is fine:
     //public String getCurrentName() throws IOException
 
@@ -833,19 +846,7 @@ public final class CBORParser extends ParserMinimalBase
         }
         throw _constructError("Invalid CBOR value token (first byte): 0x"+Integer.toHexString(ch));
     }
-
-    /**
-     * Method for forcing full read of current token, even if it might otherwise
-     * only be read if data is accessed via {@link #getText} and similar methods.
-     */
-    @Override
-    public void finishToken() throws IOException
-    {
-        if (_tokenIncomplete) {
-            _finishToken();
-        }
-    }
-
+    
     /*
     /**********************************************************
     /* Public API, traversal, nextXxxValue/nextFieldName

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -823,19 +823,6 @@ public final class CBORParser extends ParserMinimalBase
         return String.valueOf(1);
     }
 
-    // @since 2.7.2 -- will be added in `JsonParser` in 2.8
-    // see [dataformat-cbor#20]
-    /**
-     * Method for forcing full read of current token, even if it might otherwise
-     * only be read if data is accessed via {@link #getText} and similar methods.
-     */
-    public void finishToken() throws IOException
-    {
-        if (_tokenIncomplete) {
-            _finishToken();
-        }
-    }
-    
     // base impl is fine:
     //public String getCurrentName() throws IOException
 
@@ -845,6 +832,16 @@ public final class CBORParser extends ParserMinimalBase
             throw _constructError("Mismatched BREAK byte (0xFF): encountered where value expected");
         }
         throw _constructError("Invalid CBOR value token (first byte): 0x"+Integer.toHexString(ch));
+    }
+    /**
+     * Method for forcing full read of current token, even if it might otherwise
+     * only be read if data is accessed via {@link #getText} and similar methods.
+     */
+    public void finishToken() throws IOException
+    {
+        if (_tokenIncomplete) {
+            _finishToken();
+        }
     }
     
     /*

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORCommands.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORCommands.java
@@ -1,0 +1,442 @@
+package com.fasterxml.jackson.dataformat.cbor.sizer;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.LinkedList;
+
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
+
+/**
+ * Interface will be implemented for the writing method storage 
+ */
+interface Command {
+	void execute() throws JsonGenerationException, IOException;
+}
+
+/**
+ * This class is implemented by ExecuterOfArraySubCommands and
+ * ExecuterOfObjectSubCommands. It offers a method to execute all
+ * the commands stored in the LinkedList<Commands> of these classes.
+ */
+abstract class ExecuterOfSubCommands implements Command
+{
+	protected void executeQueueContent(LinkedList<Command> commandList) throws IOException
+	{				
+		for(Command element : commandList){
+			try {
+				element.execute();
+			} catch (JsonGenerationException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		
+		commandList.clear();
+	}
+}
+
+/**
+ * Class used to represent a sub array in data
+ * When the execute function is called, the array size is
+ * determined by the number of elements contained in the 
+ * LinkedList.
+ */
+class ExecuterOfArraySubCommands extends ExecuterOfSubCommands
+{
+	LinkedList<Command> 	_subListToExecute;
+	CBORGenerator			_cborGenerator;
+	
+	public ExecuterOfArraySubCommands(CBORGenerator cborGenerator, LinkedList<Command> list)
+	{
+		this._subListToExecute 	= list;
+		this._cborGenerator		= cborGenerator;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_cborGenerator.writeStartArray(_subListToExecute.size());
+		
+		executeQueueContent(_subListToExecute);
+		
+		_cborGenerator.writeEndArray();
+	}
+}
+
+/**
+ * Class used to represent a sub object in data
+ * When the execute function is called, the number of pairs
+ * is determined by dividing by two the number of elements 
+ * contained in the LinkedList.
+ */
+class ExecuterOfObjectSubCommands extends ExecuterOfSubCommands
+{
+	LinkedList<Command> 	_subListToExecute;
+	CBORGenerator			_cborGenerator;
+	
+	public ExecuterOfObjectSubCommands(CBORGenerator cborGenerator, LinkedList<Command> list)
+	{
+		this._subListToExecute 	= list;
+		this._cborGenerator		= cborGenerator;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_cborGenerator.writeStartObject(Math.round(_subListToExecute.size() / 2));
+		
+		executeQueueContent(_subListToExecute);
+		
+		_cborGenerator.writeEndObject();
+	}
+}
+
+class WriterFieldName implements Command{
+	private CBORGenerator 	_generator;
+	private String 			_name;
+	
+	public WriterFieldName(CBORGenerator generator, String name)
+	{
+		this._generator = generator;
+		this._name 		= name;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeFieldName(_name);			
+	}
+}
+
+class WriterStringStr implements Command{
+	private CBORGenerator 	_generator;
+	private String 			_text;
+	
+	public WriterStringStr(CBORGenerator generator, String text)
+	{
+		this._generator = generator;
+		this._text 		= text;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeString(_text);			
+	}
+}
+
+class WriterStringChar implements Command{
+	private CBORGenerator 	_generator;
+	private char[] 			_text;
+	private int 			_offset;
+	private int 			_len;
+	
+	public WriterStringChar(CBORGenerator generator, char[] text, int offset, int len)
+	{
+		this._generator = generator;
+		this._text 		= text;
+		this._offset 	= offset;
+		this._len 		= len;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeString(_text, _offset, _len);			
+	}
+}
+
+
+class WriterRawUTF8String implements Command{
+	private CBORGenerator 	_generator;
+	private byte[] 			_text;
+	private int 			_offset;
+	private int 			_len;
+	
+	public WriterRawUTF8String(CBORGenerator generator, byte[] text, int offset, int length)
+	{
+		this._generator = generator;
+		this._text 		= text;
+		this._offset 	= offset;
+		this._len 		= length;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeRawUTF8String(_text, _offset, _len);			
+	}
+}
+
+class WriterUTF8String implements Command{
+	private CBORGenerator 	_generator;
+	private byte[] 			_text;
+	private int 			_offset;
+	private int 			_len;
+	
+	public WriterUTF8String(CBORGenerator generator, byte[] text, int offset, int length)
+	{
+		this._generator = generator;
+		this._text 		= text;
+		this._offset 	= offset;
+		this._len 		= length;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeUTF8String(_text, _offset, _len);			
+	}
+}
+
+class WriterRaw implements Command{
+	private CBORGenerator 	_generator;
+	private String 			_text;
+	
+	public WriterRaw(CBORGenerator generator, String text)
+	{
+		this._generator = generator;
+		this._text 		= text;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeRaw(_text);			
+	}
+}
+
+class WriterRawSo implements Command{
+	private CBORGenerator 	_generator;
+	private String 			_text;
+	private int 			_offset;
+	private int 			_len;
+	
+	public WriterRawSo(CBORGenerator generator, String text, int offset, int length)
+	{
+		this._generator = generator;
+		this._text 		= text;
+		this._offset 	= offset;
+		this._len 		= length;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeRaw(_text, _offset, _len);			
+	}
+}
+
+class WriterRawCo implements Command{
+	private CBORGenerator 	_generator;
+	private char[] 			_text;
+	private int 			_offset;
+	private int 			_len;
+	
+	public WriterRawCo(CBORGenerator generator, char[] text, int offset, int length)
+	{
+		this._generator = generator;
+		this._text 		= text;
+		this._offset 	= offset;
+		this._len 		= length;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeRaw(_text, _offset, _len);			
+	}
+}
+
+
+class WriterRawC implements Command{
+	private CBORGenerator 	_generator;
+	private char 			_c;
+	
+	public WriterRawC(CBORGenerator generator, char c)
+	{
+		this._generator = generator;
+		this._c 		= c;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeRaw(_c);				
+	}
+}
+
+class WriterBinary implements Command{
+	private CBORGenerator 	_generator;
+	private Base64Variant 	_bv;
+	private byte[] 			_data;
+	private int 			_offset;
+	private int 			_len;
+	
+	public WriterBinary(CBORGenerator generator, Base64Variant bv, byte[] data, int offset, int len)
+	{
+		this._generator = generator;
+		this._bv		= bv;
+		this._data 		= data;
+		this._offset 	= offset;
+		this._len 		= len;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {
+		_generator.writeBinary(_bv, _data, _offset, _len);					
+	}
+}
+
+class WriterNumberInt implements Command{
+	private CBORGenerator 	_generator;
+	private int 			_number;
+	
+	public WriterNumberInt(CBORGenerator generator, int v)
+	{
+		this._generator = generator;
+		this._number    = v;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeNumber(_number);	
+	}
+}
+
+class WriterNumberLong implements Command{
+	private CBORGenerator 	_generator;
+	private long 			_number;
+	
+	public WriterNumberLong(CBORGenerator generator, long v)
+	{
+		this._generator = generator;
+		this._number    = v;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeNumber(_number);	
+	}
+}
+
+
+class WriterNumberBigInteger implements Command{
+	private CBORGenerator 	_generator;
+	private BigInteger		_number;
+	
+	public WriterNumberBigInteger(CBORGenerator generator, BigInteger v)
+	{
+		this._generator = generator;
+		this._number    = v;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeNumber(_number);	
+	}
+}
+
+class WriterNumberDouble implements Command{
+	private CBORGenerator 	_generator;
+	private double		_number;
+	
+	public WriterNumberDouble(CBORGenerator generator, double v)
+	{
+		this._generator = generator;
+		this._number    = v;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeNumber(_number);	
+	}
+}
+
+class WriterNumberFloat implements Command{
+	private CBORGenerator 	_generator;
+	private float			_number;
+	
+	public WriterNumberFloat(CBORGenerator generator, float v)
+	{
+		this._generator = generator;
+		this._number    = v;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeNumber(_number);	
+	}
+}
+
+class WriterNumberBigDecimal implements Command{
+	private CBORGenerator 	_generator;
+	private BigDecimal		_number;
+	
+	public WriterNumberBigDecimal(CBORGenerator generator, BigDecimal v)
+	{
+		this._generator = generator;
+		this._number    = v;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeNumber(_number);	
+	}
+}
+
+class WriterNumberString implements Command{
+	private CBORGenerator 	_generator;
+	private String			_number;
+	
+	public WriterNumberString(CBORGenerator generator, String encodedValue)
+	{
+		this._generator = generator;
+		this._number    = encodedValue;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeNumber(_number);	
+	}
+}
+
+
+class WriterBoolean implements Command{
+	private CBORGenerator 	_generator;
+	private boolean			_state;
+	
+	public WriterBoolean(CBORGenerator generator, boolean state)
+	{
+		this._generator = generator;
+		this._state    	= state;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeBoolean(_state);	
+	}
+}
+
+class WriterNull implements Command{
+	private CBORGenerator 	_generator;
+	
+	public WriterNull(CBORGenerator generator)
+	{
+		this._generator = generator;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeNull();	
+	}
+}
+
+class WriterTag implements Command{
+	private CBORGenerator 	_generator;
+	private int				_tag;
+	
+	public WriterTag(CBORGenerator generator, int tag)
+	{
+		this._generator = generator;
+		this._tag    	= tag;
+	}
+
+	@Override
+	public void execute() throws JsonGenerationException, IOException {	
+		_generator.writeTag(_tag);	
+	}
+}

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORCommands.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORCommands.java
@@ -19,7 +19,7 @@ abstract class Command {
         _cborGenerator = cborGenerator;
     }
 
-    abstract void execute() throws JsonGenerationException, IOException;
+    public abstract void execute() throws JsonGenerationException, IOException;
 }
 
 /**

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORCommands.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORCommands.java
@@ -3,440 +3,388 @@ package com.fasterxml.jackson.dataformat.cbor.sizer;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.LinkedList;
+import java.util.Queue;
 
 import com.fasterxml.jackson.core.Base64Variant;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 
 /**
- * Interface will be implemented for the writing method storage 
+ * Interface will be implemented for the writing method storage
  */
-interface Command {
-	void execute() throws JsonGenerationException, IOException;
+abstract class Command {
+    protected CBORGenerator _cborGenerator;
+
+    public Command(CBORGenerator cborGenerator) {
+        _cborGenerator = cborGenerator;
+    }
+
+    abstract void execute() throws JsonGenerationException, IOException;
 }
 
 /**
  * This class is implemented by ExecuterOfArraySubCommands and
- * ExecuterOfObjectSubCommands. It offers a method to execute all
- * the commands stored in the LinkedList<Commands> of these classes.
+ * ExecuterOfObjectSubCommands. It offers a method to execute all the commands
+ * stored in the LinkedList<Commands> of these classes.
  */
-abstract class ExecuterOfSubCommands implements Command
-{
-	protected void executeQueueContent(LinkedList<Command> commandList) throws IOException
-	{				
-		for(Command element : commandList){
-			try {
-				element.execute();
-			} catch (JsonGenerationException e) {
-				e.printStackTrace();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-		
-		commandList.clear();
-	}
+abstract class ExecuterOfSubCommands extends Command {
+    protected Queue<Command> _subListToExecute;
+
+    public ExecuterOfSubCommands(CBORGenerator cborGenerator, Queue<Command> list) {
+        super(cborGenerator);
+        this._subListToExecute = list;
+    }
+
+    protected void executeQueueContent(Queue<Command> commandList) throws IOException {
+        try {
+            for (Command element : commandList) {
+                element.execute();
+            }
+        } finally {
+            commandList.clear();
+        }
+    }
 }
 
 /**
- * Class used to represent a sub array in data
- * When the execute function is called, the array size is
- * determined by the number of elements contained in the 
- * LinkedList.
+ * Class used to represent a sub array in data When the execute function is
+ * called, the array size is determined by the number of elements contained in
+ * the LinkedList.
  */
-class ExecuterOfArraySubCommands extends ExecuterOfSubCommands
-{
-	LinkedList<Command> 	_subListToExecute;
-	CBORGenerator			_cborGenerator;
-	
-	public ExecuterOfArraySubCommands(CBORGenerator cborGenerator, LinkedList<Command> list)
-	{
-		this._subListToExecute 	= list;
-		this._cborGenerator		= cborGenerator;
-	}
+class ExecuterOfArraySubCommands extends ExecuterOfSubCommands {
+    public ExecuterOfArraySubCommands(CBORGenerator cborGenerator, Queue<Command> list) {
+        super(cborGenerator, list);
+    }
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_cborGenerator.writeStartArray(_subListToExecute.size());
-		
-		executeQueueContent(_subListToExecute);
-		
-		_cborGenerator.writeEndArray();
-	}
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeStartArray(_subListToExecute.size());
+
+        executeQueueContent(_subListToExecute);
+
+        _cborGenerator.writeEndArray();
+    }
 }
 
 /**
- * Class used to represent a sub object in data
- * When the execute function is called, the number of pairs
- * is determined by dividing by two the number of elements 
- * contained in the LinkedList.
+ * Class used to represent a sub object in data When the execute function is
+ * called, the number of pairs is determined by dividing by two the number of
+ * elements contained in the LinkedList.
  */
-class ExecuterOfObjectSubCommands extends ExecuterOfSubCommands
-{
-	LinkedList<Command> 	_subListToExecute;
-	CBORGenerator			_cborGenerator;
-	
-	public ExecuterOfObjectSubCommands(CBORGenerator cborGenerator, LinkedList<Command> list)
-	{
-		this._subListToExecute 	= list;
-		this._cborGenerator		= cborGenerator;
-	}
+class ExecuterOfObjectSubCommands extends ExecuterOfSubCommands {
+    public ExecuterOfObjectSubCommands(CBORGenerator cborGenerator, Queue<Command> list) {
+        super(cborGenerator, list);
+    }
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_cborGenerator.writeStartObject(Math.round(_subListToExecute.size() / 2));
-		
-		executeQueueContent(_subListToExecute);
-		
-		_cborGenerator.writeEndObject();
-	}
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeStartObject(Math.round(_subListToExecute.size() / 2));
+
+        executeQueueContent(_subListToExecute);
+
+        _cborGenerator.writeEndObject();
+    }
 }
 
-class WriterFieldName implements Command{
-	private CBORGenerator 	_generator;
-	private String 			_name;
-	
-	public WriterFieldName(CBORGenerator generator, String name)
-	{
-		this._generator = generator;
-		this._name 		= name;
-	}
+class WriterFieldName extends Command {
+    private String _name;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeFieldName(_name);			
-	}
+    public WriterFieldName(CBORGenerator generator, String name) {
+        super(generator);
+        this._name = name;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeFieldName(_name);
+    }
 }
 
-class WriterStringStr implements Command{
-	private CBORGenerator 	_generator;
-	private String 			_text;
-	
-	public WriterStringStr(CBORGenerator generator, String text)
-	{
-		this._generator = generator;
-		this._text 		= text;
-	}
+class WriterStringStr extends Command {
+    private String _text;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeString(_text);			
-	}
+    public WriterStringStr(CBORGenerator generator, String text) {
+        super(generator);
+        this._text = text;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeString(_text);
+    }
 }
 
-class WriterStringChar implements Command{
-	private CBORGenerator 	_generator;
-	private char[] 			_text;
-	private int 			_offset;
-	private int 			_len;
-	
-	public WriterStringChar(CBORGenerator generator, char[] text, int offset, int len)
-	{
-		this._generator = generator;
-		this._text 		= text;
-		this._offset 	= offset;
-		this._len 		= len;
-	}
+class WriterStringChar extends Command {
+    private char[] _text;
+    private int _offset;
+    private int _len;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeString(_text, _offset, _len);			
-	}
+    public WriterStringChar(CBORGenerator generator, char[] text, int offset, int len) {
+        super(generator);
+        this._text = text;
+        this._offset = offset;
+        this._len = len;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeString(_text, _offset, _len);
+    }
 }
 
+class WriterRawUTF8String extends Command {
+    private byte[] _text;
+    private int _offset;
+    private int _len;
 
-class WriterRawUTF8String implements Command{
-	private CBORGenerator 	_generator;
-	private byte[] 			_text;
-	private int 			_offset;
-	private int 			_len;
-	
-	public WriterRawUTF8String(CBORGenerator generator, byte[] text, int offset, int length)
-	{
-		this._generator = generator;
-		this._text 		= text;
-		this._offset 	= offset;
-		this._len 		= length;
-	}
+    public WriterRawUTF8String(CBORGenerator generator, byte[] text, int offset, int length) {
+        super(generator);
+        this._text = text;
+        this._offset = offset;
+        this._len = length;
+    }
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeRawUTF8String(_text, _offset, _len);			
-	}
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeRawUTF8String(_text, _offset, _len);
+    }
 }
 
-class WriterUTF8String implements Command{
-	private CBORGenerator 	_generator;
-	private byte[] 			_text;
-	private int 			_offset;
-	private int 			_len;
-	
-	public WriterUTF8String(CBORGenerator generator, byte[] text, int offset, int length)
-	{
-		this._generator = generator;
-		this._text 		= text;
-		this._offset 	= offset;
-		this._len 		= length;
-	}
+class WriterUTF8String extends Command {
+    private byte[] _text;
+    private int _offset;
+    private int _len;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeUTF8String(_text, _offset, _len);			
-	}
+    public WriterUTF8String(CBORGenerator generator, byte[] text, int offset, int length) {
+        super(generator);
+        this._text = text;
+        this._offset = offset;
+        this._len = length;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeUTF8String(_text, _offset, _len);
+    }
 }
 
-class WriterRaw implements Command{
-	private CBORGenerator 	_generator;
-	private String 			_text;
-	
-	public WriterRaw(CBORGenerator generator, String text)
-	{
-		this._generator = generator;
-		this._text 		= text;
-	}
+class WriterRaw extends Command {
+    private String _text;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeRaw(_text);			
-	}
+    public WriterRaw(CBORGenerator generator, String text) {
+        super(generator);
+        this._text = text;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeRaw(_text);
+    }
 }
 
-class WriterRawSo implements Command{
-	private CBORGenerator 	_generator;
-	private String 			_text;
-	private int 			_offset;
-	private int 			_len;
-	
-	public WriterRawSo(CBORGenerator generator, String text, int offset, int length)
-	{
-		this._generator = generator;
-		this._text 		= text;
-		this._offset 	= offset;
-		this._len 		= length;
-	}
+class WriterRawSo extends Command {
+    private String _text;
+    private int _offset;
+    private int _len;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeRaw(_text, _offset, _len);			
-	}
+    public WriterRawSo(CBORGenerator generator, String text, int offset, int length) {
+        super(generator);
+        this._text = text;
+        this._offset = offset;
+        this._len = length;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeRaw(_text, _offset, _len);
+    }
 }
 
-class WriterRawCo implements Command{
-	private CBORGenerator 	_generator;
-	private char[] 			_text;
-	private int 			_offset;
-	private int 			_len;
-	
-	public WriterRawCo(CBORGenerator generator, char[] text, int offset, int length)
-	{
-		this._generator = generator;
-		this._text 		= text;
-		this._offset 	= offset;
-		this._len 		= length;
-	}
+class WriterRawCo extends Command {
+    private char[] _text;
+    private int _offset;
+    private int _len;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeRaw(_text, _offset, _len);			
-	}
+    public WriterRawCo(CBORGenerator generator, char[] text, int offset, int length) {
+        super(generator);
+        this._text = text;
+        this._offset = offset;
+        this._len = length;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeRaw(_text, _offset, _len);
+    }
 }
 
+class WriterRawC extends Command {
+    private char _c;
 
-class WriterRawC implements Command{
-	private CBORGenerator 	_generator;
-	private char 			_c;
-	
-	public WriterRawC(CBORGenerator generator, char c)
-	{
-		this._generator = generator;
-		this._c 		= c;
-	}
+    public WriterRawC(CBORGenerator generator, char c) {
+        super(generator);
+        this._c = c;
+    }
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeRaw(_c);				
-	}
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeRaw(_c);
+    }
 }
 
-class WriterBinary implements Command{
-	private CBORGenerator 	_generator;
-	private Base64Variant 	_bv;
-	private byte[] 			_data;
-	private int 			_offset;
-	private int 			_len;
-	
-	public WriterBinary(CBORGenerator generator, Base64Variant bv, byte[] data, int offset, int len)
-	{
-		this._generator = generator;
-		this._bv		= bv;
-		this._data 		= data;
-		this._offset 	= offset;
-		this._len 		= len;
-	}
+class WriterBinary extends Command {
+    private Base64Variant _bv;
+    private byte[] _data;
+    private int _offset;
+    private int _len;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {
-		_generator.writeBinary(_bv, _data, _offset, _len);					
-	}
+    public WriterBinary(CBORGenerator generator, Base64Variant bv, byte[] data, int offset, int len) {
+        super(generator);
+        this._bv = bv;
+        this._data = data;
+        this._offset = offset;
+        this._len = len;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeBinary(_bv, _data, _offset, _len);
+    }
 }
 
-class WriterNumberInt implements Command{
-	private CBORGenerator 	_generator;
-	private int 			_number;
-	
-	public WriterNumberInt(CBORGenerator generator, int v)
-	{
-		this._generator = generator;
-		this._number    = v;
-	}
+class WriterNumberInt extends Command {
+    private int _number;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeNumber(_number);	
-	}
+    public WriterNumberInt(CBORGenerator generator, int v) {
+        super(generator);
+        this._number = v;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeNumber(_number);
+    }
 }
 
-class WriterNumberLong implements Command{
-	private CBORGenerator 	_generator;
-	private long 			_number;
-	
-	public WriterNumberLong(CBORGenerator generator, long v)
-	{
-		this._generator = generator;
-		this._number    = v;
-	}
+class WriterNumberLong extends Command {
+    private long _number;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeNumber(_number);	
-	}
+    public WriterNumberLong(CBORGenerator generator, long v) {
+        super(generator);
+        this._number = v;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeNumber(_number);
+    }
 }
 
+class WriterNumberBigInteger extends Command {
+    private BigInteger _number;
 
-class WriterNumberBigInteger implements Command{
-	private CBORGenerator 	_generator;
-	private BigInteger		_number;
-	
-	public WriterNumberBigInteger(CBORGenerator generator, BigInteger v)
-	{
-		this._generator = generator;
-		this._number    = v;
-	}
+    public WriterNumberBigInteger(CBORGenerator generator, BigInteger v) {
+        super(generator);
+        this._number = v;
+    }
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeNumber(_number);	
-	}
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeNumber(_number);
+    }
 }
 
-class WriterNumberDouble implements Command{
-	private CBORGenerator 	_generator;
-	private double		_number;
-	
-	public WriterNumberDouble(CBORGenerator generator, double v)
-	{
-		this._generator = generator;
-		this._number    = v;
-	}
+class WriterNumberDouble extends Command {
+    private double _number;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeNumber(_number);	
-	}
+    public WriterNumberDouble(CBORGenerator generator, double v) {
+        super(generator);
+        this._number = v;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeNumber(_number);
+    }
 }
 
-class WriterNumberFloat implements Command{
-	private CBORGenerator 	_generator;
-	private float			_number;
-	
-	public WriterNumberFloat(CBORGenerator generator, float v)
-	{
-		this._generator = generator;
-		this._number    = v;
-	}
+class WriterNumberFloat extends Command {
+    private float _number;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeNumber(_number);	
-	}
+    public WriterNumberFloat(CBORGenerator generator, float v) {
+        super(generator);
+        this._number = v;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeNumber(_number);
+    }
 }
 
-class WriterNumberBigDecimal implements Command{
-	private CBORGenerator 	_generator;
-	private BigDecimal		_number;
-	
-	public WriterNumberBigDecimal(CBORGenerator generator, BigDecimal v)
-	{
-		this._generator = generator;
-		this._number    = v;
-	}
+class WriterNumberBigDecimal extends Command {
+    private BigDecimal _number;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeNumber(_number);	
-	}
+    public WriterNumberBigDecimal(CBORGenerator generator, BigDecimal v) {
+        super(generator);
+        this._number = v;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeNumber(_number);
+    }
 }
 
-class WriterNumberString implements Command{
-	private CBORGenerator 	_generator;
-	private String			_number;
-	
-	public WriterNumberString(CBORGenerator generator, String encodedValue)
-	{
-		this._generator = generator;
-		this._number    = encodedValue;
-	}
+class WriterNumberString extends Command {
+    private String _number;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeNumber(_number);	
-	}
+    public WriterNumberString(CBORGenerator generator, String encodedValue) {
+        super(generator);
+        this._number = encodedValue;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeNumber(_number);
+    }
 }
 
+class WriterBoolean extends Command {
+    private boolean _state;
 
-class WriterBoolean implements Command{
-	private CBORGenerator 	_generator;
-	private boolean			_state;
-	
-	public WriterBoolean(CBORGenerator generator, boolean state)
-	{
-		this._generator = generator;
-		this._state    	= state;
-	}
+    public WriterBoolean(CBORGenerator generator, boolean state) {
+        super(generator);
+        this._state = state;
+    }
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeBoolean(_state);	
-	}
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeBoolean(_state);
+    }
 }
 
-class WriterNull implements Command{
-	private CBORGenerator 	_generator;
-	
-	public WriterNull(CBORGenerator generator)
-	{
-		this._generator = generator;
-	}
+class WriterNull extends Command {
+    public WriterNull(CBORGenerator generator) {
+        super(generator);
+    }
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeNull();	
-	}
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeNull();
+    }
 }
 
-class WriterTag implements Command{
-	private CBORGenerator 	_generator;
-	private int				_tag;
-	
-	public WriterTag(CBORGenerator generator, int tag)
-	{
-		this._generator = generator;
-		this._tag    	= tag;
-	}
+class WriterTag extends Command {
+    private int _tag;
 
-	@Override
-	public void execute() throws JsonGenerationException, IOException {	
-		_generator.writeTag(_tag);	
-	}
+    public WriterTag(CBORGenerator generator, int tag) {
+        super(generator);
+        this._tag = tag;
+    }
+
+    @Override
+    public void execute() throws JsonGenerationException, IOException {
+        _cborGenerator.writeTag(_tag);
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORFactorySizer.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORFactorySizer.java
@@ -13,73 +13,69 @@ import com.fasterxml.jackson.dataformat.cbor.CBORParserBootstrapper;
 import com.fasterxml.jackson.dataformat.cbor.PackageVersion;
 
 /**
- * Factory used for constructing {@link CBORParser} and {@link CBORGeneratorSizer}
- * instances; both of which handle
- * <a href="https://www.rfc-editor.org/info/rfc7049">CBOR</a>
- * encoded data.
- *<p>
+ * Factory used for constructing {@link CBORParser} and
+ * {@link CBORGeneratorSizer} instances; both of which handle
+ * <a href="https://www.rfc-editor.org/info/rfc7049">CBOR</a> encoded data.
+ * <p>
  * Extends {@link JsonFactory} mostly so that users can actually use it in place
  * of regular non-CBOR factory instances.
- *<p>
+ * <p>
  * Note on using non-byte-based sources/targets (char based, like
- * {@link java.io.Reader} and {@link java.io.Writer}): these can not be
- * used for CBOR documents; attempt will throw exception.
+ * {@link java.io.Reader} and {@link java.io.Writer}): these can not be used for
+ * CBOR documents; attempt will throw exception.
  * 
  */
-public class CBORFactorySizer extends JsonFactory
-{
-	private static final long serialVersionUID = 1; // 2.6
+public class CBORFactorySizer extends JsonFactory {
+    private static final long serialVersionUID = 1; // 2.6
 
     /*
-    /**********************************************************
-    /* Constants
-    /**********************************************************
+     * /********************************************************** /* Constants
+     * /**********************************************************
      */
 
-	/**
-     * Name used to identify CBOR format.
-     * (and returned by {@link #getFormatName()}
+    /**
+     * Name used to identify CBOR format. (and returned by
+     * {@link #getFormatName()}
      */
     public final static String FORMAT_NAME = "CBOR";
-    
+
     /**
-     * Bitfield (set of flags) of all parser features that are enabled
-     * by default.
+     * Bitfield (set of flags) of all parser features that are enabled by
+     * default.
      */
     final static int DEFAULT_CBOR_PARSER_FEATURE_FLAGS = CBORParser.Feature.collectDefaults();
 
     /**
-     * Bitfield (set of flags) of all generator features that are enabled
-     * by default.
+     * Bitfield (set of flags) of all generator features that are enabled by
+     * default.
      */
     final static int DEFAULT_CBOR_GENERATOR_FEATURE_FLAGS = CBORGeneratorSizer.Feature.collectDefaults();
 
     /*
-    /**********************************************************
-    /* Configuration
-    /**********************************************************
+     * /********************************************************** /*
+     * Configuration /**********************************************************
      */
 
     protected int _formatParserFeatures;
     protected int _formatGeneratorFeatures;
 
     /*
-    /**********************************************************
-    /* Factory construction, configuration
-    /**********************************************************
+     * /********************************************************** /* Factory
+     * construction, configuration
+     * /**********************************************************
      */
 
     /**
-     * Default constructor used to create factory instances.
-     * Creation of a factory instance is a light-weight operation,
-     * but it is still a good idea to reuse limited number of
-     * factory instances (and quite often just a single instance):
-     * factories are used as context for storing some reused
-     * processing objects (such as symbol tables parsers use)
-     * and this reuse only works within context of a single
-     * factory instance.
+     * Default constructor used to create factory instances. Creation of a
+     * factory instance is a light-weight operation, but it is still a good idea
+     * to reuse limited number of factory instances (and quite often just a
+     * single instance): factories are used as context for storing some reused
+     * processing objects (such as symbol tables parsers use) and this reuse
+     * only works within context of a single factory instance.
      */
-    public CBORFactorySizer() { this(null); }
+    public CBORFactorySizer() {
+        this(null);
+    }
 
     public CBORFactorySizer(ObjectCodec oc) {
         super(oc);
@@ -93,41 +89,37 @@ public class CBORFactorySizer extends JsonFactory
      * 
      * @since 2.2.1
      */
-    public CBORFactorySizer(CBORFactorySizer src, ObjectCodec oc)
-    {
+    public CBORFactorySizer(CBORFactorySizer src, ObjectCodec oc) {
         super(src, oc);
         _formatParserFeatures = src._formatParserFeatures;
         _formatGeneratorFeatures = src._formatGeneratorFeatures;
     }
 
     @Override
-    public CBORFactorySizer copy()
-    {
+    public CBORFactorySizer copy() {
         _checkInvalidCopy(CBORFactorySizer.class);
         // note: as with base class, must NOT copy mapper reference
         return new CBORFactorySizer(this, null);
     }
 
     /*
-    /**********************************************************
-    /* Serializable overrides
-    /**********************************************************
+     * /********************************************************** /*
+     * Serializable overrides
+     * /**********************************************************
      */
 
     /**
-     * Method that we need to override to actually make restoration go
-     * through constructors etc.
-     * Also: must be overridden by sub-classes as well.
+     * Method that we need to override to actually make restoration go through
+     * constructors etc. Also: must be overridden by sub-classes as well.
      */
     @Override
     protected Object readResolve() {
         return new CBORFactorySizer(this, _objectCodec);
     }
 
-    /*                                                                                       
-    /**********************************************************                              
-    /* Versioned                                                                             
-    /**********************************************************                              
+    /*
+     * /********************************************************** /* Versioned
+     * /**********************************************************
      */
 
     @Override
@@ -136,11 +128,11 @@ public class CBORFactorySizer extends JsonFactory
     }
 
     /*
-    /**********************************************************
-    /* Format detection functionality
-    /**********************************************************
+     * /********************************************************** /* Format
+     * detection functionality
+     * /**********************************************************
      */
-    
+
     @Override
     public String getFormatName() {
         return FORMAT_NAME;
@@ -155,9 +147,8 @@ public class CBORFactorySizer extends JsonFactory
     }
 
     /*
-    /**********************************************************
-    /* Capability introspection
-    /**********************************************************
+     * /********************************************************** /* Capability
+     * introspection /**********************************************************
      */
 
     @Override
@@ -174,19 +165,18 @@ public class CBORFactorySizer extends JsonFactory
     public Class<CBORGenerator.Feature> getFormatWriteFeatureType() {
         return CBORGenerator.Feature.class;
     }
-    
+
     /*
-    /**********************************************************
-    /* Configuration, parser settings
-    /**********************************************************
+     * /********************************************************** /*
+     * Configuration, parser settings
+     * /**********************************************************
      */
 
     /**
-     * Method for enabling or disabling specified parser feature
-     * (check {@link CBORParser.Feature} for list of features)
+     * Method for enabling or disabling specified parser feature (check
+     * {@link CBORParser.Feature} for list of features)
      */
-    public final CBORFactorySizer configure(CBORParser.Feature f, boolean state)
-    {
+    public final CBORFactorySizer configure(CBORParser.Feature f, boolean state) {
         if (state) {
             enable(f);
         } else {
@@ -196,8 +186,8 @@ public class CBORFactorySizer extends JsonFactory
     }
 
     /**
-     * Method for enabling specified parser feature
-     * (check {@link CBORParser.Feature} for list of features)
+     * Method for enabling specified parser feature (check
+     * {@link CBORParser.Feature} for list of features)
      */
     public CBORFactorySizer enable(CBORParser.Feature f) {
         _formatParserFeatures |= f.getMask();
@@ -205,8 +195,8 @@ public class CBORFactorySizer extends JsonFactory
     }
 
     /**
-     * Method for disabling specified parser features
-     * (check {@link CBORParser.Feature} for list of features)
+     * Method for disabling specified parser features (check
+     * {@link CBORParser.Feature} for list of features)
      */
     public CBORFactorySizer disable(CBORParser.Feature f) {
         _formatParserFeatures &= ~f.getMask();
@@ -221,14 +211,14 @@ public class CBORFactorySizer extends JsonFactory
     }
 
     /*
-    /**********************************************************
-    /* Configuration, generator settings
-    /**********************************************************
+     * /********************************************************** /*
+     * Configuration, generator settings
+     * /**********************************************************
      */
 
     /**
-     * Method for enabling or disabling specified generator feature
-     * (check {@link CBORGeneratorSizer.Feature} for list of features)
+     * Method for enabling or disabling specified generator feature (check
+     * {@link CBORGeneratorSizer.Feature} for list of features)
      */
     public CBORFactorySizer configure(CBORGenerator.Feature f, boolean state) {
         if (state) {
@@ -239,21 +229,20 @@ public class CBORFactorySizer extends JsonFactory
         return this;
     }
 
-
     /**
-     * Method for enabling specified generator features
-     * (check {@link CBORGeneratorSizer.Feature} for list of features)
+     * Method for enabling specified generator features (check
+     * {@link CBORGeneratorSizer.Feature} for list of features)
      */
-	public CBORFactorySizer enable(CBORGenerator.Feature f) {
+    public CBORFactorySizer enable(CBORGenerator.Feature f) {
         _formatGeneratorFeatures |= f.getMask();
         return this;
     }
 
     /**
-     * Method for disabling specified generator feature
-     * (check {@link CBORGeneratorSizer.Feature} for list of features)
+     * Method for disabling specified generator feature (check
+     * {@link CBORGeneratorSizer.Feature} for list of features)
      */
-	public CBORFactorySizer disable(CBORGenerator.Feature f) {
+    public CBORFactorySizer disable(CBORGenerator.Feature f) {
         _formatGeneratorFeatures &= ~f.getMask();
         return this;
     }
@@ -261,14 +250,14 @@ public class CBORFactorySizer extends JsonFactory
     /**
      * Check whether specified generator feature is enabled.
      */
-	public boolean isEnabled(CBORGenerator.Feature f) {
+    public boolean isEnabled(CBORGenerator.Feature f) {
         return (_formatGeneratorFeatures & f.getMask()) != 0;
     }
 
     /*
-    /**********************************************************
-    /* Overridden parser factory methods, new (2.1)
-    /**********************************************************
+     * /********************************************************** /* Overridden
+     * parser factory methods, new (2.1)
+     * /**********************************************************
      */
 
     @SuppressWarnings("resource")
@@ -298,41 +287,41 @@ public class CBORFactorySizer extends JsonFactory
     }
 
     /*
-    /**********************************************************
-    /* Overridden generator factory methods
-    /**********************************************************
+     * /********************************************************** /* Overridden
+     * generator factory methods
+     * /**********************************************************
      */
 
     /**
-     * Method for constructing {@link JsonGenerator} for generating
-     * CBOR-encoded output.
-     *<p>
-     * Since CBOR format always uses UTF-8 internally, <code>enc</code>
-     * argument is ignored.
+     * Method for constructing {@link JsonGenerator} for generating CBOR-encoded
+     * output.
+     * <p>
+     * Since CBOR format always uses UTF-8 internally, <code>enc</code> argument
+     * is ignored.
      */
     @Override
     public CBORGeneratorSizer createGenerator(OutputStream out, JsonEncoding enc) throws IOException {
-        return _createCBORGeneratorSizer(_createContext(out, false),
-                _generatorFeatures, _formatGeneratorFeatures, _objectCodec, out);
+        return _createCBORGeneratorSizer(_createContext(out, false), _generatorFeatures, _formatGeneratorFeatures,
+                _objectCodec, out);
     }
 
     /**
-     * Method for constructing {@link JsonGenerator} for generating
-     * CBOR-encoded output.
-     *<p>
-     * Since CBOR format always uses UTF-8 internally, no encoding need
-     * to be passed to this method.
+     * Method for constructing {@link JsonGenerator} for generating CBOR-encoded
+     * output.
+     * <p>
+     * Since CBOR format always uses UTF-8 internally, no encoding need to be
+     * passed to this method.
      */
     @Override
     public CBORGeneratorSizer createGenerator(OutputStream out) throws IOException {
-        return _createCBORGeneratorSizer(_createContext(out, false),
-                _generatorFeatures, _formatGeneratorFeatures, _objectCodec, out);
+        return _createCBORGeneratorSizer(_createContext(out, false), _generatorFeatures, _formatGeneratorFeatures,
+                _objectCodec, out);
     }
 
     /*
-    /******************************************************
-    /* Overridden internal factory methods
-    /******************************************************
+     * /****************************************************** /* Overridden
+     * internal factory methods
+     * /******************************************************
      */
 
     @Override
@@ -341,20 +330,16 @@ public class CBORFactorySizer extends JsonFactory
     }
 
     /**
-     * Overridable factory method that actually instantiates desired
-     * parser.
+     * Overridable factory method that actually instantiates desired parser.
      */
     @Override
-    protected CBORParser _createParser(InputStream in, IOContext ctxt) throws IOException
-    {
-        return new CBORParserBootstrapper(ctxt, in).constructParser(_factoryFeatures,
-                _parserFeatures, _formatParserFeatures,
-                _objectCodec, _byteSymbolCanonicalizer);
+    protected CBORParser _createParser(InputStream in, IOContext ctxt) throws IOException {
+        return new CBORParserBootstrapper(ctxt, in).constructParser(_factoryFeatures, _parserFeatures,
+                _formatParserFeatures, _objectCodec, _byteSymbolCanonicalizer);
     }
 
     /**
-     * Overridable factory method that actually instantiates desired
-     * parser.
+     * Overridable factory method that actually instantiates desired parser.
      */
     @Override
     protected JsonParser _createParser(Reader r, IOContext ctxt) throws IOException {
@@ -362,21 +347,18 @@ public class CBORFactorySizer extends JsonFactory
     }
 
     @Override
-    protected JsonParser _createParser(char[] data, int offset, int len, IOContext ctxt,
-            boolean recyclable) throws IOException {
+    protected JsonParser _createParser(char[] data, int offset, int len, IOContext ctxt, boolean recyclable)
+            throws IOException {
         return _nonByteSource();
     }
 
     /**
-     * Overridable factory method that actually instantiates desired
-     * parser.
+     * Overridable factory method that actually instantiates desired parser.
      */
     @Override
-    protected CBORParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException
-    {
-        return new CBORParserBootstrapper(ctxt, data, offset, len).constructParser(
-                _factoryFeatures, _parserFeatures, _formatParserFeatures,
-                _objectCodec, _byteSymbolCanonicalizer);
+    protected CBORParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException {
+        return new CBORParserBootstrapper(ctxt, data, offset, len).constructParser(_factoryFeatures, _parserFeatures,
+                _formatParserFeatures, _objectCodec, _byteSymbolCanonicalizer);
     }
 
     @Override
@@ -386,8 +368,7 @@ public class CBORFactorySizer extends JsonFactory
 
     @Override
     protected CBORGeneratorSizer _createUTF8Generator(OutputStream out, IOContext ctxt) throws IOException {
-        return _createCBORGeneratorSizer(ctxt,
-                _generatorFeatures, _formatGeneratorFeatures, _objectCodec, out);
+        return _createCBORGeneratorSizer(ctxt, _generatorFeatures, _formatGeneratorFeatures, _objectCodec, out);
     }
 
     @Override
@@ -395,17 +376,17 @@ public class CBORFactorySizer extends JsonFactory
         return _nonByteTarget();
     }
 
-    private final CBORGeneratorSizer _createCBORGeneratorSizer(IOContext ctxt,
-            int stdFeat, int formatFeat, ObjectCodec codec, OutputStream out) throws IOException
-    {
+    private final CBORGeneratorSizer _createCBORGeneratorSizer(IOContext ctxt, int stdFeat, int formatFeat,
+            ObjectCodec codec, OutputStream out) throws IOException {
         // false -> we won't manage the stream unless explicitly directed to
         CBORGeneratorSizer gen = new CBORGeneratorSizer(ctxt, stdFeat, formatFeat, _objectCodec, out);
-        /*if (CBORGenerator.Feature.WRITE_TYPE_HEADER.enabledIn(formatFeat)) {
-            gen.writeTag(CBORConstants.TAG_ID_SELF_DESCRIBE); 
-        }*/
+        /*
+         * if (CBORGenerator.Feature.WRITE_TYPE_HEADER.enabledIn(formatFeat)) {
+         * gen.writeTag(CBORConstants.TAG_ID_SELF_DESCRIBE); }
+         */
         return gen;
     }
-       
+
     protected <T> T _nonByteTarget() {
         throw new UnsupportedOperationException("Can not create generator for non-byte-based target");
     }

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORFactorySizer.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORFactorySizer.java
@@ -1,0 +1,416 @@
+package com.fasterxml.jackson.dataformat.cbor.sizer;
+
+import java.io.*;
+import java.net.URL;
+
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.format.InputAccessor;
+import com.fasterxml.jackson.core.format.MatchStrength;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
+import com.fasterxml.jackson.dataformat.cbor.CBORParser;
+import com.fasterxml.jackson.dataformat.cbor.CBORParserBootstrapper;
+import com.fasterxml.jackson.dataformat.cbor.PackageVersion;
+
+/**
+ * Factory used for constructing {@link CBORParser} and {@link CBORGeneratorSizer}
+ * instances; both of which handle
+ * <a href="https://www.rfc-editor.org/info/rfc7049">CBOR</a>
+ * encoded data.
+ *<p>
+ * Extends {@link JsonFactory} mostly so that users can actually use it in place
+ * of regular non-CBOR factory instances.
+ *<p>
+ * Note on using non-byte-based sources/targets (char based, like
+ * {@link java.io.Reader} and {@link java.io.Writer}): these can not be
+ * used for CBOR documents; attempt will throw exception.
+ * 
+ */
+public class CBORFactorySizer extends JsonFactory
+{
+	private static final long serialVersionUID = 1; // 2.6
+
+    /*
+    /**********************************************************
+    /* Constants
+    /**********************************************************
+     */
+
+	/**
+     * Name used to identify CBOR format.
+     * (and returned by {@link #getFormatName()}
+     */
+    public final static String FORMAT_NAME = "CBOR";
+    
+    /**
+     * Bitfield (set of flags) of all parser features that are enabled
+     * by default.
+     */
+    final static int DEFAULT_CBOR_PARSER_FEATURE_FLAGS = CBORParser.Feature.collectDefaults();
+
+    /**
+     * Bitfield (set of flags) of all generator features that are enabled
+     * by default.
+     */
+    final static int DEFAULT_CBOR_GENERATOR_FEATURE_FLAGS = CBORGeneratorSizer.Feature.collectDefaults();
+
+    /*
+    /**********************************************************
+    /* Configuration
+    /**********************************************************
+     */
+
+    protected int _formatParserFeatures;
+    protected int _formatGeneratorFeatures;
+
+    /*
+    /**********************************************************
+    /* Factory construction, configuration
+    /**********************************************************
+     */
+
+    /**
+     * Default constructor used to create factory instances.
+     * Creation of a factory instance is a light-weight operation,
+     * but it is still a good idea to reuse limited number of
+     * factory instances (and quite often just a single instance):
+     * factories are used as context for storing some reused
+     * processing objects (such as symbol tables parsers use)
+     * and this reuse only works within context of a single
+     * factory instance.
+     */
+    public CBORFactorySizer() { this(null); }
+
+    public CBORFactorySizer(ObjectCodec oc) {
+        super(oc);
+        _formatParserFeatures = DEFAULT_CBOR_PARSER_FEATURE_FLAGS;
+        _formatGeneratorFeatures = DEFAULT_CBOR_GENERATOR_FEATURE_FLAGS;
+    }
+
+    /**
+     * Note: REQUIRES at least 2.2.1 -- unfortunate intra-patch dep but seems
+     * preferable to just leaving bug be as is
+     * 
+     * @since 2.2.1
+     */
+    public CBORFactorySizer(CBORFactorySizer src, ObjectCodec oc)
+    {
+        super(src, oc);
+        _formatParserFeatures = src._formatParserFeatures;
+        _formatGeneratorFeatures = src._formatGeneratorFeatures;
+    }
+
+    @Override
+    public CBORFactorySizer copy()
+    {
+        _checkInvalidCopy(CBORFactorySizer.class);
+        // note: as with base class, must NOT copy mapper reference
+        return new CBORFactorySizer(this, null);
+    }
+
+    /*
+    /**********************************************************
+    /* Serializable overrides
+    /**********************************************************
+     */
+
+    /**
+     * Method that we need to override to actually make restoration go
+     * through constructors etc.
+     * Also: must be overridden by sub-classes as well.
+     */
+    @Override
+    protected Object readResolve() {
+        return new CBORFactorySizer(this, _objectCodec);
+    }
+
+    /*                                                                                       
+    /**********************************************************                              
+    /* Versioned                                                                             
+    /**********************************************************                              
+     */
+
+    @Override
+    public Version version() {
+        return PackageVersion.VERSION;
+    }
+
+    /*
+    /**********************************************************
+    /* Format detection functionality
+    /**********************************************************
+     */
+    
+    @Override
+    public String getFormatName() {
+        return FORMAT_NAME;
+    }
+
+    // Defaults work fine for this:
+    // public boolean canUseSchema(FormatSchema schema) { }
+
+    @Override
+    public MatchStrength hasFormat(InputAccessor acc) throws IOException {
+        return CBORParserBootstrapper.hasCBORFormat(acc);
+    }
+
+    /*
+    /**********************************************************
+    /* Capability introspection
+    /**********************************************************
+     */
+
+    @Override
+    public boolean canHandleBinaryNatively() {
+        return true;
+    }
+
+    @Override // since 2.6
+    public Class<CBORParser.Feature> getFormatReadFeatureType() {
+        return CBORParser.Feature.class;
+    }
+
+    @Override // since 2.6
+    public Class<CBORGenerator.Feature> getFormatWriteFeatureType() {
+        return CBORGenerator.Feature.class;
+    }
+    
+    /*
+    /**********************************************************
+    /* Configuration, parser settings
+    /**********************************************************
+     */
+
+    /**
+     * Method for enabling or disabling specified parser feature
+     * (check {@link CBORParser.Feature} for list of features)
+     */
+    public final CBORFactorySizer configure(CBORParser.Feature f, boolean state)
+    {
+        if (state) {
+            enable(f);
+        } else {
+            disable(f);
+        }
+        return this;
+    }
+
+    /**
+     * Method for enabling specified parser feature
+     * (check {@link CBORParser.Feature} for list of features)
+     */
+    public CBORFactorySizer enable(CBORParser.Feature f) {
+        _formatParserFeatures |= f.getMask();
+        return this;
+    }
+
+    /**
+     * Method for disabling specified parser features
+     * (check {@link CBORParser.Feature} for list of features)
+     */
+    public CBORFactorySizer disable(CBORParser.Feature f) {
+        _formatParserFeatures &= ~f.getMask();
+        return this;
+    }
+
+    /**
+     * Checked whether specified parser feature is enabled.
+     */
+    public final boolean isEnabled(CBORParser.Feature f) {
+        return (_formatParserFeatures & f.getMask()) != 0;
+    }
+
+    /*
+    /**********************************************************
+    /* Configuration, generator settings
+    /**********************************************************
+     */
+
+    /**
+     * Method for enabling or disabling specified generator feature
+     * (check {@link CBORGeneratorSizer.Feature} for list of features)
+     */
+    public CBORFactorySizer configure(CBORGenerator.Feature f, boolean state) {
+        if (state) {
+            enable(f);
+        } else {
+            disable(f);
+        }
+        return this;
+    }
+
+
+    /**
+     * Method for enabling specified generator features
+     * (check {@link CBORGeneratorSizer.Feature} for list of features)
+     */
+	public CBORFactorySizer enable(CBORGenerator.Feature f) {
+        _formatGeneratorFeatures |= f.getMask();
+        return this;
+    }
+
+    /**
+     * Method for disabling specified generator feature
+     * (check {@link CBORGeneratorSizer.Feature} for list of features)
+     */
+	public CBORFactorySizer disable(CBORGenerator.Feature f) {
+        _formatGeneratorFeatures &= ~f.getMask();
+        return this;
+    }
+
+    /**
+     * Check whether specified generator feature is enabled.
+     */
+	public boolean isEnabled(CBORGenerator.Feature f) {
+        return (_formatGeneratorFeatures & f.getMask()) != 0;
+    }
+
+    /*
+    /**********************************************************
+    /* Overridden parser factory methods, new (2.1)
+    /**********************************************************
+     */
+
+    @SuppressWarnings("resource")
+    @Override
+    public CBORParser createParser(File f) throws IOException {
+        return _createParser(new FileInputStream(f), _createContext(f, true));
+    }
+
+    @Override
+    public CBORParser createParser(URL url) throws IOException {
+        return _createParser(_optimizedStreamFromURL(url), _createContext(url, true));
+    }
+
+    @Override
+    public CBORParser createParser(InputStream in) throws IOException {
+        return _createParser(in, _createContext(in, false));
+    }
+
+    @Override
+    public CBORParser createParser(byte[] data) throws IOException {
+        return _createParser(data, 0, data.length, _createContext(data, true));
+    }
+
+    @Override
+    public CBORParser createParser(byte[] data, int offset, int len) throws IOException {
+        return _createParser(data, offset, len, _createContext(data, true));
+    }
+
+    /*
+    /**********************************************************
+    /* Overridden generator factory methods
+    /**********************************************************
+     */
+
+    /**
+     * Method for constructing {@link JsonGenerator} for generating
+     * CBOR-encoded output.
+     *<p>
+     * Since CBOR format always uses UTF-8 internally, <code>enc</code>
+     * argument is ignored.
+     */
+    @Override
+    public CBORGeneratorSizer createGenerator(OutputStream out, JsonEncoding enc) throws IOException {
+        return _createCBORGeneratorSizer(_createContext(out, false),
+                _generatorFeatures, _formatGeneratorFeatures, _objectCodec, out);
+    }
+
+    /**
+     * Method for constructing {@link JsonGenerator} for generating
+     * CBOR-encoded output.
+     *<p>
+     * Since CBOR format always uses UTF-8 internally, no encoding need
+     * to be passed to this method.
+     */
+    @Override
+    public CBORGeneratorSizer createGenerator(OutputStream out) throws IOException {
+        return _createCBORGeneratorSizer(_createContext(out, false),
+                _generatorFeatures, _formatGeneratorFeatures, _objectCodec, out);
+    }
+
+    /*
+    /******************************************************
+    /* Overridden internal factory methods
+    /******************************************************
+     */
+
+    @Override
+    protected IOContext _createContext(Object srcRef, boolean resourceManaged) {
+        return super._createContext(srcRef, resourceManaged);
+    }
+
+    /**
+     * Overridable factory method that actually instantiates desired
+     * parser.
+     */
+    @Override
+    protected CBORParser _createParser(InputStream in, IOContext ctxt) throws IOException
+    {
+        return new CBORParserBootstrapper(ctxt, in).constructParser(_factoryFeatures,
+                _parserFeatures, _formatParserFeatures,
+                _objectCodec, _byteSymbolCanonicalizer);
+    }
+
+    /**
+     * Overridable factory method that actually instantiates desired
+     * parser.
+     */
+    @Override
+    protected JsonParser _createParser(Reader r, IOContext ctxt) throws IOException {
+        return _nonByteSource();
+    }
+
+    @Override
+    protected JsonParser _createParser(char[] data, int offset, int len, IOContext ctxt,
+            boolean recyclable) throws IOException {
+        return _nonByteSource();
+    }
+
+    /**
+     * Overridable factory method that actually instantiates desired
+     * parser.
+     */
+    @Override
+    protected CBORParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException
+    {
+        return new CBORParserBootstrapper(ctxt, data, offset, len).constructParser(
+                _factoryFeatures, _parserFeatures, _formatParserFeatures,
+                _objectCodec, _byteSymbolCanonicalizer);
+    }
+
+    @Override
+    protected CBORGeneratorSizer _createGenerator(Writer out, IOContext ctxt) throws IOException {
+        return _nonByteTarget();
+    }
+
+    @Override
+    protected CBORGeneratorSizer _createUTF8Generator(OutputStream out, IOContext ctxt) throws IOException {
+        return _createCBORGeneratorSizer(ctxt,
+                _generatorFeatures, _formatGeneratorFeatures, _objectCodec, out);
+    }
+
+    @Override
+    protected Writer _createWriter(OutputStream out, JsonEncoding enc, IOContext ctxt) throws IOException {
+        return _nonByteTarget();
+    }
+
+    private final CBORGeneratorSizer _createCBORGeneratorSizer(IOContext ctxt,
+            int stdFeat, int formatFeat, ObjectCodec codec, OutputStream out) throws IOException
+    {
+        // false -> we won't manage the stream unless explicitly directed to
+        CBORGeneratorSizer gen = new CBORGeneratorSizer(ctxt, stdFeat, formatFeat, _objectCodec, out);
+        /*if (CBORGenerator.Feature.WRITE_TYPE_HEADER.enabledIn(formatFeat)) {
+            gen.writeTag(CBORConstants.TAG_ID_SELF_DESCRIBE); 
+        }*/
+        return gen;
+    }
+       
+    protected <T> T _nonByteTarget() {
+        throw new UnsupportedOperationException("Can not create generator for non-byte-based target");
+    }
+
+    protected <T> T _nonByteSource() {
+        throw new UnsupportedOperationException("Can not create generator for non-byte-based source");
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORFactorySizer.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORFactorySizer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.format.InputAccessor;
 import com.fasterxml.jackson.core.format.MatchStrength;
 import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.dataformat.cbor.CBORConstants;
 import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import com.fasterxml.jackson.dataformat.cbor.CBORParser;
 import com.fasterxml.jackson.dataformat.cbor.CBORParserBootstrapper;
@@ -29,8 +30,7 @@ public class CBORFactorySizer extends JsonFactory {
     private static final long serialVersionUID = 1; // 2.6
 
     /*
-     * /********************************************************** /* Constants
-     * /**********************************************************
+     * Constants
      */
 
     /**
@@ -52,17 +52,14 @@ public class CBORFactorySizer extends JsonFactory {
     final static int DEFAULT_CBOR_GENERATOR_FEATURE_FLAGS = CBORGeneratorSizer.Feature.collectDefaults();
 
     /*
-     * /********************************************************** /*
-     * Configuration /**********************************************************
+     * Configuration
      */
 
     protected int _formatParserFeatures;
     protected int _formatGeneratorFeatures;
 
     /*
-     * /********************************************************** /* Factory
-     * construction, configuration
-     * /**********************************************************
+     * Factory construction, configuration
      */
 
     /**
@@ -380,10 +377,11 @@ public class CBORFactorySizer extends JsonFactory {
             ObjectCodec codec, OutputStream out) throws IOException {
         // false -> we won't manage the stream unless explicitly directed to
         CBORGeneratorSizer gen = new CBORGeneratorSizer(ctxt, stdFeat, formatFeat, _objectCodec, out);
-        /*
-         * if (CBORGenerator.Feature.WRITE_TYPE_HEADER.enabledIn(formatFeat)) {
-         * gen.writeTag(CBORConstants.TAG_ID_SELF_DESCRIBE); }
-         */
+
+        if (CBORGenerator.Feature.WRITE_TYPE_HEADER.enabledIn(formatFeat)) {
+            gen.writeTag(CBORConstants.TAG_ID_SELF_DESCRIBE);
+        }
+
         return gen;
     }
 

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORGeneratorSizer.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORGeneratorSizer.java
@@ -5,8 +5,10 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Stack;
+
 import com.fasterxml.jackson.core.Base64Variant;
-import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.base.GeneratorBase;
 import com.fasterxml.jackson.core.io.IOContext;
@@ -14,370 +16,312 @@ import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 
 /**
  * 
- * Implementation of JsonGenerator which permits to use definite size array
- * amd maps when it is possible. To do so, the data is encoded when all the array
- * or map content is known. This class should not be used in the cases where
- * the memory efficiency is a priority.
+ * Implementation of JsonGenerator which permits to use definite size array amd
+ * maps when it is possible. To do so, the data is encoded when all the array or
+ * map content is known. This class should not be used in the cases where the
+ * memory efficiency is a priority.
  */
-public class CBORGeneratorSizer extends GeneratorBase
-{
-	/**
-	 * This class decorate CBORGenerator. All the writing methods are wrapped	 * 
-	 */
-	private CBORGenerator _cborGenerator;
-		
-	/**
-	 * For arrays and map, the data is stored in these lists. 
-	 */
-	private LinkedList<LinkedList<Command>>	_commandsQueueList;
-	private LinkedList<Command> 			_commandsQueue;
-	
-	/**
-	 * The queuing is activated only for the map and arrays
-	 */
-	private Boolean _queuingIsEnabled;
-		
-	/**
-	 * The constructor initializes the wrapped CBORGenerator.
-	 * @param ctxt
-	 * @param stdFeatures
-	 * @param formatFeatures
-	 * @param codec
-	 * @param out
-	 */
-	public CBORGeneratorSizer(IOContext ctxt, int stdFeatures, int formatFeatures, ObjectCodec codec, OutputStream out)
-	{
-		super(stdFeatures, codec);
-		_cborGenerator 			= new CBORGenerator(ctxt, stdFeatures, formatFeatures, codec, out);
-		
-		_commandsQueue 			= new LinkedList<Command>();
-		_commandsQueueList		= new LinkedList<LinkedList<Command>>();
-		_queuingIsEnabled 		= false;		
-	}
-	
-	private void enqueue(Command cmd)
-	{
-		_commandsQueue.add(cmd);		
-	}
-	
-	private void clearQueue()
-	{
-		_commandsQueue.clear();
-	}
-	
-	private void pushQueueAndCreateNewOne()
-	{
-		this._commandsQueueList.push(this._commandsQueue);			
-		this._commandsQueue = new LinkedList<Command>();
-		this._queuingIsEnabled = true;
-	}
-		
-	/**
-	 * All the commands stored are executed first in first out.
-	 * @param commandList
-	 * @throws IOException
-	 */
-	private void executeQueueContent(LinkedList<Command> commandList) throws IOException
-	{				
-		for(Command element : commandList){
-			try {
-				element.execute();
-			} catch (JsonGenerationException e) {
-				e.printStackTrace();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-		
-		clearQueue();
-	}
+public class CBORGeneratorSizer extends GeneratorBase {
+    /**
+     * This class decorate CBORGenerator. All the writing methods are wrapped
+     */
+    private CBORGenerator _cborGenerator;
 
-	@Override
-	public void flush() throws IOException {
-		_cborGenerator.flush();		
-	}
+    /**
+     * For arrays and map, the data is stored in these lists.
+     */
+    private Stack<Queue<Command>> _commandsQueueStack;
+    private Queue<Command> _commandsQueue;
 
-	@Override
-	/**
-	 * The array is opened only at the end when the number of object is known.
-	 * The queuing is activated and the current list of data is pushed in 
-	 * the queue list. 
-	 */
-	public void writeStartArray() throws IOException {
-		pushQueueAndCreateNewOne();
-	}
-
-	@Override
-	/**
-	 * The content of the last array is added to the list of element to write
-	 * If this is the last end, all the stored commands are executed
-	 */
-	public void writeEndArray() throws IOException {
-		if(!this._commandsQueueList.isEmpty())
-		{
-			Command tmpSubCommand = new ExecuterOfArraySubCommands(_cborGenerator, _commandsQueue);
-			this._commandsQueue = this._commandsQueueList.pop();
-			this._commandsQueue.add(tmpSubCommand);
-		}
-				
-		if(this._commandsQueueList.isEmpty())
-		{
-			this.executeQueueContent(_commandsQueue);	
-			this._queuingIsEnabled = false;
-		}		
-	}
-
-	@Override
-	/**
-	 * The map is opened only at the end when the number of object is known.
-	 * The queuing is activated and the current list of data is pushed in 
-	 * the queue list. 
-	 */
-	public void writeStartObject() throws IOException {
-		pushQueueAndCreateNewOne();
-	}
-
-	@Override
-	/**
-	 * The content of the map array is added to the list of element to write
-	 * If this is the last end, all the stored commands are executed
-	 */
-	public void writeEndObject() throws IOException {
-		if(!this._commandsQueueList.isEmpty())
-		{
-			Command tmpSubCommand = new ExecuterOfObjectSubCommands(_cborGenerator, _commandsQueue);
-			this._commandsQueue = this._commandsQueueList.pop();
-			this._commandsQueue.add(tmpSubCommand);
-		}
-				
-		// Write data
-		if(this._commandsQueueList.isEmpty())
-		{
-			this.executeQueueContent(_commandsQueue);
-			this._queuingIsEnabled = false;
-		}			
-	}
-	
-	/** 
-	 * **********************************************************
-	 * Wrapped methods
-	 * **********************************************************
-	 * if the queuing is activated, the commands are stored
-	 * and will be executed on the last map or array end.
-	 */
-	
-	@Override
-	public void writeFieldName(String name) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterFieldName(this._cborGenerator, name));
-		}
-		else{
-			_cborGenerator.writeFieldName(name);
-		}	
-	}
-		
-	@Override
-	public void writeString(String text) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterStringStr(this._cborGenerator, text));
-		}
-		else{
-			_cborGenerator.writeString(text);
-		}			
-	}
-	
-	@Override
-	public void writeString(char[] text, int offset, int len) throws IOException {			
-		if(_queuingIsEnabled){
-			enqueue(new WriterStringChar(this._cborGenerator, text, offset, len));
-		}
-		else{
-			_cborGenerator.writeString(text, offset, len);
-		}
-	}
-	
-	@Override
-	public void writeRawUTF8String(byte[] text, int offset, int length) throws IOException {	
-		if(_queuingIsEnabled){
-			enqueue(new WriterRawUTF8String(this._cborGenerator, text, offset, length));
-		}
-		else{
-			_cborGenerator.writeRawUTF8String(text, offset, length);
-		}
-	}
-	
-	@Override
-	public void writeUTF8String(byte[] text, int offset, int length) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterUTF8String(this._cborGenerator, text, offset, length));
-		}
-		else{
-			_cborGenerator.writeUTF8String(text, offset, length);
-		}		
-	}
-	
-	@Override
-	public void writeRaw(String text) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterRaw(this._cborGenerator, text));
-		}
-		else{	
-			_cborGenerator.writeRaw(text);
-		}		
-	}
-	
-	@Override
-	public void writeRaw(String text, int offset, int len) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterRawSo(this._cborGenerator, text, offset, len));
-		}
-		else{	
-			_cborGenerator.writeRaw(text, offset, len);
-		}		
-	}
-	
-	@Override
-	public void writeRaw(char[] text, int offset, int len) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterRawCo(this._cborGenerator, text, offset, len));
-		}
-		else{	
-			_cborGenerator.writeRaw(text, offset, len);	
-		}
-	}
-	
-	@Override
-	public void writeRaw(char c) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterRawC(this._cborGenerator, c));
-		}
-		else{	
-			_cborGenerator.writeRaw(c);		
-		}
-	}
-	
-	@Override
-	public void writeBinary(Base64Variant bv, byte[] data, int offset, int len) throws IOException {	
-		if(_queuingIsEnabled){
-			enqueue(new WriterBinary(this._cborGenerator, bv, data, offset, len));
-		}
-		else{	
-			_cborGenerator.writeBinary(bv, data, offset, len);
-		}
-	}
-	
-	@Override
-	public void writeNumber(int v) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterNumberInt(_cborGenerator, v));
-		}
-		else{	
-			_cborGenerator.writeNumber(v);	
-		}		
-	}
-	
-	@Override
-	public void writeNumber(long v) throws IOException {	
-		if(_queuingIsEnabled){
-			enqueue(new WriterNumberLong(_cborGenerator, v));
-		}
-		else{	
-			_cborGenerator.writeNumber(v);
-		}	
-	}
-	
-	@Override
-	public void writeNumber(BigInteger v) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterNumberBigInteger(_cborGenerator, v));
-		}
-		else{	
-			_cborGenerator.writeNumber(v);
-		}	
-	}
-	
-	@Override
-	public void writeNumber(double v) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterNumberDouble(_cborGenerator, v));
-		}
-		else{	
-			_cborGenerator.writeNumber(v);
-		}			
-	}
-	
-	@Override
-	public void writeNumber(float v) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterNumberFloat(_cborGenerator, v));
-		}
-		else{	
-			_cborGenerator.writeNumber(v);
-		}	
-	}
-	
-	@Override
-	public void writeNumber(BigDecimal v) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterNumberBigDecimal(_cborGenerator, v));
-		}
-		else{	
-			_cborGenerator.writeNumber(v);
-		}		
-	}
-	
-	@Override
-	public void writeNumber(String encodedValue) throws IOException {
-		if(_queuingIsEnabled){
-			enqueue(new WriterNumberString(_cborGenerator, encodedValue));
-		}
-		else{	
-			_cborGenerator.writeNumber(encodedValue);
-		}			
-	}
-	
-	@Override
-	public void writeBoolean(boolean state) throws IOException {			
-		if(_queuingIsEnabled){
-			enqueue(new WriterBoolean(_cborGenerator, state));
-		}
-		else{	
-			_cborGenerator.writeBoolean(state);
-		}	
-	}
-		
-    public void writeTag(int tagId) throws IOException
-    {
-		if(_queuingIsEnabled){
-			enqueue(new WriterTag(_cborGenerator, tagId));
-		}
-		else{	
-	    	_cborGenerator.writeTag(tagId);
-		}	
+    /**
+     * The constructor initializes the wrapped CBORGenerator.
+     * 
+     * @param ctxt
+     * @param stdFeatures
+     * @param formatFeatures
+     * @param codec
+     * @param out
+     */
+    public CBORGeneratorSizer(IOContext ctxt, int stdFeatures, int formatFeatures, ObjectCodec codec,
+            OutputStream out) {
+        super(stdFeatures, codec);
+        _cborGenerator = new CBORGenerator(ctxt, stdFeatures, formatFeatures, codec, out);
     }
 
-	@Override
-	public void writeNull() throws IOException {	
-		if(_queuingIsEnabled){
-			enqueue(new WriterNull(_cborGenerator));
-		}
-		else{	
-			_cborGenerator.writeNull();
-		}
-	}
-	
+    private void enqueue(Command cmd) {
+        _commandsQueue.add(cmd);
+    }
+
+    private void clearQueue() {
+        _commandsQueue.clear();
+    }
+
+    /**
+     * The queuing is activated only for the map and arrays
+     */
+    private boolean isQueuingIsEnabled() {
+        return (_commandsQueueStack != null);
+    }
+
+    private void createObjectContext() {
+        if (_commandsQueueStack == null) {
+            _commandsQueueStack = new Stack<Queue<Command>>();
+        }
+        if (_commandsQueue != null && !_commandsQueue.isEmpty()) {
+            _commandsQueueStack.add(_commandsQueue);
+        }
+        _commandsQueue = new LinkedList<Command>();
+    }
+
     @Override
-	public void close() throws IOException
-    {
-    	_cborGenerator.close();
+    public void flush() throws IOException {
+        _cborGenerator.flush();
     }
 
-	@Override
-	protected void _releaseBuffers() {		
-	}
+    @Override
+    /**
+     * The array is opened only at the end when the number of object is known.
+     * The queuing is activated and the current list of data is pushed in the
+     * queue list.
+     */
+    public void writeStartArray() throws IOException {
+        createObjectContext();
+    }
 
-	@Override
-	protected void _verifyValueWrite(String typeMsg) throws IOException {		
-	}	
+    @Override
+    /**
+     * The content of the last array is added to the list of element to write.
+     * If this is the last end, all the stored commands are executed
+     */
+    public void writeEndArray() throws IOException {
+        Command arraySubCommand = new ExecuterOfArraySubCommands(_cborGenerator, _commandsQueue);
+        if (!_commandsQueueStack.empty()) {
+            _commandsQueue = _commandsQueueStack.pop();
+            _commandsQueue.add(arraySubCommand);
+        } else {
+            arraySubCommand.execute();
+        }
+    }
+
+    @Override
+    /**
+     * The map is opened only at the end when the number of object is known. The
+     * queuing is activated and the current list of data is pushed in the queue
+     * list.
+     */
+    public void writeStartObject() throws IOException {
+        createObjectContext();
+    }
+
+    @Override
+    /**
+     * The content of the map array is added to the list of element to write If
+     * this is the last end, all the stored commands are executed
+     */
+    public void writeEndObject() throws IOException {
+        Command objectSubCommand = new ExecuterOfObjectSubCommands(_cborGenerator, _commandsQueue);
+        if (!_commandsQueueStack.empty()) {
+            _commandsQueue = _commandsQueueStack.pop();
+            _commandsQueue.add(objectSubCommand);
+        } else {
+            objectSubCommand.execute();
+        }
+    }
+
+    /**
+     * Wrapped methods: if the queuing is activated, the commands are stored and
+     * will be executed on the last map or array end.
+     */
+
+    @Override
+    public void writeFieldName(String name) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterFieldName(this._cborGenerator, name));
+        } else {
+            _cborGenerator.writeFieldName(name);
+        }
+    }
+
+    @Override
+    public void writeString(String text) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterStringStr(this._cborGenerator, text));
+        } else {
+            _cborGenerator.writeString(text);
+        }
+    }
+
+    @Override
+    public void writeString(char[] text, int offset, int len) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterStringChar(this._cborGenerator, text, offset, len));
+        } else {
+            _cborGenerator.writeString(text, offset, len);
+        }
+    }
+
+    @Override
+    public void writeRawUTF8String(byte[] text, int offset, int length) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterRawUTF8String(this._cborGenerator, text, offset, length));
+        } else {
+            _cborGenerator.writeRawUTF8String(text, offset, length);
+        }
+    }
+
+    @Override
+    public void writeUTF8String(byte[] text, int offset, int length) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterUTF8String(this._cborGenerator, text, offset, length));
+        } else {
+            _cborGenerator.writeUTF8String(text, offset, length);
+        }
+    }
+
+    @Override
+    public void writeRaw(String text) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterRaw(this._cborGenerator, text));
+        } else {
+            _cborGenerator.writeRaw(text);
+        }
+    }
+
+    @Override
+    public void writeRaw(String text, int offset, int len) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterRawSo(this._cborGenerator, text, offset, len));
+        } else {
+            _cborGenerator.writeRaw(text, offset, len);
+        }
+    }
+
+    @Override
+    public void writeRaw(char[] text, int offset, int len) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterRawCo(this._cborGenerator, text, offset, len));
+        } else {
+            _cborGenerator.writeRaw(text, offset, len);
+        }
+    }
+
+    @Override
+    public void writeRaw(char c) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterRawC(this._cborGenerator, c));
+        } else {
+            _cborGenerator.writeRaw(c);
+        }
+    }
+
+    @Override
+    public void writeBinary(Base64Variant bv, byte[] data, int offset, int len) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterBinary(this._cborGenerator, bv, data, offset, len));
+        } else {
+            _cborGenerator.writeBinary(bv, data, offset, len);
+        }
+    }
+
+    @Override
+    public void writeNumber(int v) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterNumberInt(_cborGenerator, v));
+        } else {
+            _cborGenerator.writeNumber(v);
+        }
+    }
+
+    @Override
+    public void writeNumber(long v) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterNumberLong(_cborGenerator, v));
+        } else {
+            _cborGenerator.writeNumber(v);
+        }
+    }
+
+    @Override
+    public void writeNumber(BigInteger v) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterNumberBigInteger(_cborGenerator, v));
+        } else {
+            _cborGenerator.writeNumber(v);
+        }
+    }
+
+    @Override
+    public void writeNumber(double v) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterNumberDouble(_cborGenerator, v));
+        } else {
+            _cborGenerator.writeNumber(v);
+        }
+    }
+
+    @Override
+    public void writeNumber(float v) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterNumberFloat(_cborGenerator, v));
+        } else {
+            _cborGenerator.writeNumber(v);
+        }
+    }
+
+    @Override
+    public void writeNumber(BigDecimal v) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterNumberBigDecimal(_cborGenerator, v));
+        } else {
+            _cborGenerator.writeNumber(v);
+        }
+    }
+
+    @Override
+    public void writeNumber(String encodedValue) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterNumberString(_cborGenerator, encodedValue));
+        } else {
+            _cborGenerator.writeNumber(encodedValue);
+        }
+    }
+
+    @Override
+    public void writeBoolean(boolean state) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterBoolean(_cborGenerator, state));
+        } else {
+            _cborGenerator.writeBoolean(state);
+        }
+    }
+
+    public void writeTag(int tagId) throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterTag(_cborGenerator, tagId));
+        } else {
+            _cborGenerator.writeTag(tagId);
+        }
+    }
+
+    @Override
+    public void writeNull() throws IOException {
+        if (isQueuingIsEnabled()) {
+            enqueue(new WriterNull(_cborGenerator));
+        } else {
+            _cborGenerator.writeNull();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        _cborGenerator.close();
+    }
+
+    @Override
+    protected void _releaseBuffers() {
+    }
+
+    @Override
+    protected void _verifyValueWrite(String typeMsg) throws IOException {
+    }
 }
-

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORGeneratorSizer.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORGeneratorSizer.java
@@ -46,28 +46,23 @@ public class CBORGeneratorSizer extends GeneratorBase {
             OutputStream out) {
         super(stdFeatures, codec);
         _cborGenerator = new CBORGenerator(ctxt, stdFeatures, formatFeatures, codec, out);
+
+        _commandsQueueStack = new Stack<Queue<Command>>();
     }
 
     private void enqueue(Command cmd) {
         _commandsQueue.add(cmd);
     }
 
-    private void clearQueue() {
-        _commandsQueue.clear();
-    }
-
     /**
      * The queuing is activated only for the map and arrays
      */
-    private boolean isQueuingIsEnabled() {
-        return (_commandsQueueStack != null);
+    private boolean isQueuingEnabled() {
+        return _commandsQueue != null;
     }
 
     private void createObjectContext() {
-        if (_commandsQueueStack == null) {
-            _commandsQueueStack = new Stack<Queue<Command>>();
-        }
-        if (_commandsQueue != null && !_commandsQueue.isEmpty()) {
+        if (_commandsQueue != null) {
             _commandsQueueStack.add(_commandsQueue);
         }
         _commandsQueue = new LinkedList<Command>();
@@ -100,6 +95,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
             _commandsQueue.add(arraySubCommand);
         } else {
             arraySubCommand.execute();
+            _commandsQueue = null;
         }
     }
 
@@ -125,6 +121,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
             _commandsQueue.add(objectSubCommand);
         } else {
             objectSubCommand.execute();
+            _commandsQueue = null;
         }
     }
 
@@ -135,7 +132,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeFieldName(String name) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterFieldName(this._cborGenerator, name));
         } else {
             _cborGenerator.writeFieldName(name);
@@ -144,7 +141,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeString(String text) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterStringStr(this._cborGenerator, text));
         } else {
             _cborGenerator.writeString(text);
@@ -153,7 +150,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeString(char[] text, int offset, int len) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterStringChar(this._cborGenerator, text, offset, len));
         } else {
             _cborGenerator.writeString(text, offset, len);
@@ -162,7 +159,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeRawUTF8String(byte[] text, int offset, int length) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterRawUTF8String(this._cborGenerator, text, offset, length));
         } else {
             _cborGenerator.writeRawUTF8String(text, offset, length);
@@ -171,7 +168,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeUTF8String(byte[] text, int offset, int length) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterUTF8String(this._cborGenerator, text, offset, length));
         } else {
             _cborGenerator.writeUTF8String(text, offset, length);
@@ -180,7 +177,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeRaw(String text) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterRaw(this._cborGenerator, text));
         } else {
             _cborGenerator.writeRaw(text);
@@ -189,7 +186,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeRaw(String text, int offset, int len) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterRawSo(this._cborGenerator, text, offset, len));
         } else {
             _cborGenerator.writeRaw(text, offset, len);
@@ -198,7 +195,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeRaw(char[] text, int offset, int len) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterRawCo(this._cborGenerator, text, offset, len));
         } else {
             _cborGenerator.writeRaw(text, offset, len);
@@ -207,7 +204,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeRaw(char c) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterRawC(this._cborGenerator, c));
         } else {
             _cborGenerator.writeRaw(c);
@@ -216,7 +213,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeBinary(Base64Variant bv, byte[] data, int offset, int len) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterBinary(this._cborGenerator, bv, data, offset, len));
         } else {
             _cborGenerator.writeBinary(bv, data, offset, len);
@@ -225,7 +222,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeNumber(int v) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterNumberInt(_cborGenerator, v));
         } else {
             _cborGenerator.writeNumber(v);
@@ -234,7 +231,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeNumber(long v) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterNumberLong(_cborGenerator, v));
         } else {
             _cborGenerator.writeNumber(v);
@@ -243,7 +240,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeNumber(BigInteger v) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterNumberBigInteger(_cborGenerator, v));
         } else {
             _cborGenerator.writeNumber(v);
@@ -252,7 +249,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeNumber(double v) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterNumberDouble(_cborGenerator, v));
         } else {
             _cborGenerator.writeNumber(v);
@@ -261,7 +258,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeNumber(float v) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterNumberFloat(_cborGenerator, v));
         } else {
             _cborGenerator.writeNumber(v);
@@ -270,7 +267,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeNumber(BigDecimal v) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterNumberBigDecimal(_cborGenerator, v));
         } else {
             _cborGenerator.writeNumber(v);
@@ -279,7 +276,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeNumber(String encodedValue) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterNumberString(_cborGenerator, encodedValue));
         } else {
             _cborGenerator.writeNumber(encodedValue);
@@ -288,7 +285,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeBoolean(boolean state) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterBoolean(_cborGenerator, state));
         } else {
             _cborGenerator.writeBoolean(state);
@@ -296,7 +293,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
     }
 
     public void writeTag(int tagId) throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterTag(_cborGenerator, tagId));
         } else {
             _cborGenerator.writeTag(tagId);
@@ -305,7 +302,7 @@ public class CBORGeneratorSizer extends GeneratorBase {
 
     @Override
     public void writeNull() throws IOException {
-        if (isQueuingIsEnabled()) {
+        if (isQueuingEnabled()) {
             enqueue(new WriterNull(_cborGenerator));
         } else {
             _cborGenerator.writeNull();

--- a/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORGeneratorSizer.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORGeneratorSizer.java
@@ -1,0 +1,383 @@
+package com.fasterxml.jackson.dataformat.cbor.sizer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.LinkedList;
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.base.GeneratorBase;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
+
+/**
+ * 
+ * Implementation of JsonGenerator which permits to use definite size array
+ * amd maps when it is possible. To do so, the data is encoded when all the array
+ * or map content is known. This class should not be used in the cases where
+ * the memory efficiency is a priority.
+ */
+public class CBORGeneratorSizer extends GeneratorBase
+{
+	/**
+	 * This class decorate CBORGenerator. All the writing methods are wrapped	 * 
+	 */
+	private CBORGenerator _cborGenerator;
+		
+	/**
+	 * For arrays and map, the data is stored in these lists. 
+	 */
+	private LinkedList<LinkedList<Command>>	_commandsQueueList;
+	private LinkedList<Command> 			_commandsQueue;
+	
+	/**
+	 * The queuing is activated only for the map and arrays
+	 */
+	private Boolean _queuingIsEnabled;
+		
+	/**
+	 * The constructor initializes the wrapped CBORGenerator.
+	 * @param ctxt
+	 * @param stdFeatures
+	 * @param formatFeatures
+	 * @param codec
+	 * @param out
+	 */
+	public CBORGeneratorSizer(IOContext ctxt, int stdFeatures, int formatFeatures, ObjectCodec codec, OutputStream out)
+	{
+		super(stdFeatures, codec);
+		_cborGenerator 			= new CBORGenerator(ctxt, stdFeatures, formatFeatures, codec, out);
+		
+		_commandsQueue 			= new LinkedList<Command>();
+		_commandsQueueList		= new LinkedList<LinkedList<Command>>();
+		_queuingIsEnabled 		= false;		
+	}
+	
+	private void enqueue(Command cmd)
+	{
+		_commandsQueue.add(cmd);		
+	}
+	
+	private void clearQueue()
+	{
+		_commandsQueue.clear();
+	}
+	
+	private void pushQueueAndCreateNewOne()
+	{
+		this._commandsQueueList.push(this._commandsQueue);			
+		this._commandsQueue = new LinkedList<Command>();
+		this._queuingIsEnabled = true;
+	}
+		
+	/**
+	 * All the commands stored are executed first in first out.
+	 * @param commandList
+	 * @throws IOException
+	 */
+	private void executeQueueContent(LinkedList<Command> commandList) throws IOException
+	{				
+		for(Command element : commandList){
+			try {
+				element.execute();
+			} catch (JsonGenerationException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		
+		clearQueue();
+	}
+
+	@Override
+	public void flush() throws IOException {
+		_cborGenerator.flush();		
+	}
+
+	@Override
+	/**
+	 * The array is opened only at the end when the number of object is known.
+	 * The queuing is activated and the current list of data is pushed in 
+	 * the queue list. 
+	 */
+	public void writeStartArray() throws IOException {
+		pushQueueAndCreateNewOne();
+	}
+
+	@Override
+	/**
+	 * The content of the last array is added to the list of element to write
+	 * If this is the last end, all the stored commands are executed
+	 */
+	public void writeEndArray() throws IOException {
+		if(!this._commandsQueueList.isEmpty())
+		{
+			Command tmpSubCommand = new ExecuterOfArraySubCommands(_cborGenerator, _commandsQueue);
+			this._commandsQueue = this._commandsQueueList.pop();
+			this._commandsQueue.add(tmpSubCommand);
+		}
+				
+		if(this._commandsQueueList.isEmpty())
+		{
+			this.executeQueueContent(_commandsQueue);	
+			this._queuingIsEnabled = false;
+		}		
+	}
+
+	@Override
+	/**
+	 * The map is opened only at the end when the number of object is known.
+	 * The queuing is activated and the current list of data is pushed in 
+	 * the queue list. 
+	 */
+	public void writeStartObject() throws IOException {
+		pushQueueAndCreateNewOne();
+	}
+
+	@Override
+	/**
+	 * The content of the map array is added to the list of element to write
+	 * If this is the last end, all the stored commands are executed
+	 */
+	public void writeEndObject() throws IOException {
+		if(!this._commandsQueueList.isEmpty())
+		{
+			Command tmpSubCommand = new ExecuterOfObjectSubCommands(_cborGenerator, _commandsQueue);
+			this._commandsQueue = this._commandsQueueList.pop();
+			this._commandsQueue.add(tmpSubCommand);
+		}
+				
+		// Write data
+		if(this._commandsQueueList.isEmpty())
+		{
+			this.executeQueueContent(_commandsQueue);
+			this._queuingIsEnabled = false;
+		}			
+	}
+	
+	/** 
+	 * **********************************************************
+	 * Wrapped methods
+	 * **********************************************************
+	 * if the queuing is activated, the commands are stored
+	 * and will be executed on the last map or array end.
+	 */
+	
+	@Override
+	public void writeFieldName(String name) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterFieldName(this._cborGenerator, name));
+		}
+		else{
+			_cborGenerator.writeFieldName(name);
+		}	
+	}
+		
+	@Override
+	public void writeString(String text) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterStringStr(this._cborGenerator, text));
+		}
+		else{
+			_cborGenerator.writeString(text);
+		}			
+	}
+	
+	@Override
+	public void writeString(char[] text, int offset, int len) throws IOException {			
+		if(_queuingIsEnabled){
+			enqueue(new WriterStringChar(this._cborGenerator, text, offset, len));
+		}
+		else{
+			_cborGenerator.writeString(text, offset, len);
+		}
+	}
+	
+	@Override
+	public void writeRawUTF8String(byte[] text, int offset, int length) throws IOException {	
+		if(_queuingIsEnabled){
+			enqueue(new WriterRawUTF8String(this._cborGenerator, text, offset, length));
+		}
+		else{
+			_cborGenerator.writeRawUTF8String(text, offset, length);
+		}
+	}
+	
+	@Override
+	public void writeUTF8String(byte[] text, int offset, int length) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterUTF8String(this._cborGenerator, text, offset, length));
+		}
+		else{
+			_cborGenerator.writeUTF8String(text, offset, length);
+		}		
+	}
+	
+	@Override
+	public void writeRaw(String text) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterRaw(this._cborGenerator, text));
+		}
+		else{	
+			_cborGenerator.writeRaw(text);
+		}		
+	}
+	
+	@Override
+	public void writeRaw(String text, int offset, int len) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterRawSo(this._cborGenerator, text, offset, len));
+		}
+		else{	
+			_cborGenerator.writeRaw(text, offset, len);
+		}		
+	}
+	
+	@Override
+	public void writeRaw(char[] text, int offset, int len) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterRawCo(this._cborGenerator, text, offset, len));
+		}
+		else{	
+			_cborGenerator.writeRaw(text, offset, len);	
+		}
+	}
+	
+	@Override
+	public void writeRaw(char c) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterRawC(this._cborGenerator, c));
+		}
+		else{	
+			_cborGenerator.writeRaw(c);		
+		}
+	}
+	
+	@Override
+	public void writeBinary(Base64Variant bv, byte[] data, int offset, int len) throws IOException {	
+		if(_queuingIsEnabled){
+			enqueue(new WriterBinary(this._cborGenerator, bv, data, offset, len));
+		}
+		else{	
+			_cborGenerator.writeBinary(bv, data, offset, len);
+		}
+	}
+	
+	@Override
+	public void writeNumber(int v) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterNumberInt(_cborGenerator, v));
+		}
+		else{	
+			_cborGenerator.writeNumber(v);	
+		}		
+	}
+	
+	@Override
+	public void writeNumber(long v) throws IOException {	
+		if(_queuingIsEnabled){
+			enqueue(new WriterNumberLong(_cborGenerator, v));
+		}
+		else{	
+			_cborGenerator.writeNumber(v);
+		}	
+	}
+	
+	@Override
+	public void writeNumber(BigInteger v) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterNumberBigInteger(_cborGenerator, v));
+		}
+		else{	
+			_cborGenerator.writeNumber(v);
+		}	
+	}
+	
+	@Override
+	public void writeNumber(double v) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterNumberDouble(_cborGenerator, v));
+		}
+		else{	
+			_cborGenerator.writeNumber(v);
+		}			
+	}
+	
+	@Override
+	public void writeNumber(float v) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterNumberFloat(_cborGenerator, v));
+		}
+		else{	
+			_cborGenerator.writeNumber(v);
+		}	
+	}
+	
+	@Override
+	public void writeNumber(BigDecimal v) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterNumberBigDecimal(_cborGenerator, v));
+		}
+		else{	
+			_cborGenerator.writeNumber(v);
+		}		
+	}
+	
+	@Override
+	public void writeNumber(String encodedValue) throws IOException {
+		if(_queuingIsEnabled){
+			enqueue(new WriterNumberString(_cborGenerator, encodedValue));
+		}
+		else{	
+			_cborGenerator.writeNumber(encodedValue);
+		}			
+	}
+	
+	@Override
+	public void writeBoolean(boolean state) throws IOException {			
+		if(_queuingIsEnabled){
+			enqueue(new WriterBoolean(_cborGenerator, state));
+		}
+		else{	
+			_cborGenerator.writeBoolean(state);
+		}	
+	}
+		
+    public void writeTag(int tagId) throws IOException
+    {
+		if(_queuingIsEnabled){
+			enqueue(new WriterTag(_cborGenerator, tagId));
+		}
+		else{	
+	    	_cborGenerator.writeTag(tagId);
+		}	
+    }
+
+	@Override
+	public void writeNull() throws IOException {	
+		if(_queuingIsEnabled){
+			enqueue(new WriterNull(_cborGenerator));
+		}
+		else{	
+			_cborGenerator.writeNull();
+		}
+	}
+	
+    @Override
+	public void close() throws IOException
+    {
+    	_cborGenerator.close();
+    }
+
+	@Override
+	protected void _releaseBuffers() {		
+	}
+
+	@Override
+	protected void _verifyValueWrite(String typeMsg) throws IOException {		
+	}	
+}
+

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/CBORTestBase.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/CBORTestBase.java
@@ -11,7 +11,7 @@ import org.junit.Assert;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-abstract class CBORTestBase
+public abstract class CBORTestBase
     extends junit.framework.TestCase
 {
 
@@ -37,20 +37,20 @@ abstract class CBORTestBase
     protected CBORParser cborParser(CBORFactory f, byte[] input) throws IOException {
         return f.createParser(input);
     }
-
+    
     protected CBORParser cborParser(CBORFactory f, InputStream in) throws IOException {
         return f.createParser(in);
     }
     
     protected ObjectMapper cborMapper() {
         return new ObjectMapper(cborFactory());
-    }
-    
+    } 
+        
     protected CBORFactory cborFactory() {
         CBORFactory f = new CBORFactory();
         return f;
     }
-
+    
     protected byte[] cborDoc(String json) throws IOException {
         return cborDoc(cborFactory(), json);
     }
@@ -82,7 +82,7 @@ abstract class CBORTestBase
     {
         return f.createGenerator(result, null);
     }
-
+    
     /*
     /**********************************************************
     /* Additional assertion methods
@@ -228,6 +228,26 @@ abstract class CBORTestBase
         return sw.toString();
     }
     
+    protected static String byteToHexString(byte[] cborValue) 
+    {
+      StringBuilder hexValue = new StringBuilder();
+
+      String prefix = "";
+
+      for(byte b : cborValue) {
+
+        hexValue.append(prefix + byteToHexString(b));
+        prefix = " ";
+      }
+
+      return hexValue.toString();
+    }
+
+    protected static String byteToHexString(byte byteVal) 
+    {
+      return String.format("%02x", byteVal);
+    }
+    
     /*
     /**********************************************************
     /* Other helper methods
@@ -241,4 +261,5 @@ abstract class CBORTestBase
     protected static String quote(String str) {
         return '"'+str+'"';
     }
+    
 }

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORTestBaseSizer.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORTestBaseSizer.java
@@ -9,21 +9,18 @@ import com.fasterxml.jackson.dataformat.cbor.CBORParser;
 import com.fasterxml.jackson.dataformat.cbor.CBORTestBase;
 import com.fasterxml.jackson.dataformat.cbor.sizer.CBORFactorySizer;
 
-public abstract class CBORTestBaseSizer extends CBORTestBase
-{
-	 /*
-    /**********************************************************
-    /* Factory methods
-    /**********************************************************
+public abstract class CBORTestBaseSizer extends CBORTestBase {
+    /*
+     * Factory methods
      */
-  
+
     @Override
-	protected CBORParser cborParser(byte[] input) throws IOException {
+    protected CBORParser cborParser(byte[] input) throws IOException {
         return cborParser(cborFactorySizer(), input);
     }
 
     @Override
-	protected CBORParser cborParser(InputStream in) throws IOException {
+    protected CBORParser cborParser(InputStream in) throws IOException {
         CBORFactorySizer f = cborFactorySizer();
         return cborParser(f, in);
     }
@@ -31,53 +28,46 @@ public abstract class CBORTestBaseSizer extends CBORTestBase
     protected CBORParser cborParser(CBORFactorySizer f, byte[] input) throws IOException {
         return f.createParser(input);
     }
-    
-	protected CBORParser cborParser(CBORFactorySizer f, InputStream in) throws IOException {
+
+    protected CBORParser cborParser(CBORFactorySizer f, InputStream in) throws IOException {
         return f.createParser(in);
     }
-    
+
     @Override
-	protected ObjectMapper cborMapper() {
+    protected ObjectMapper cborMapper() {
         return new ObjectMapper(cborFactorySizer());
-    } 
-     
-	protected CBORFactorySizer cborFactorySizer() {
+    }
+
+    protected CBORFactorySizer cborFactorySizer() {
         CBORFactorySizer f = new CBORFactorySizer();
         return f;
     }
-    
+
     @Override
-	protected byte[] cborDoc(String json) throws IOException {
+    protected byte[] cborDoc(String json) throws IOException {
         return cborDoc(cborFactorySizer(), json);
     }
 
-	protected byte[] cborDoc(CBORFactorySizer cborF, String json) throws IOException
-    {
+    protected byte[] cborDoc(CBORFactorySizer cborF, String json) throws IOException {
         JsonFactory jf = new JsonFactory();
         JsonParser jp = jf.createParser(json);
         ByteArrayOutputStream out = new ByteArrayOutputStream(json.length());
         JsonGenerator dest = cborF.createGenerator(out);
-    	
+
         while (jp.nextToken() != null) {
-        	dest.copyCurrentEvent(jp);
+            dest.copyCurrentEvent(jp);
         }
         jp.close();
         dest.close();
         return out.toByteArray();
     }
 
-	protected CBORGeneratorSizer cborGeneratorSizer(ByteArrayOutputStream result)
-        throws IOException
-    {
+    protected CBORGeneratorSizer cborGeneratorSizer(ByteArrayOutputStream result) throws IOException {
         return cborGeneratorSizer(cborFactorySizer(), result);
     }
 
-	protected CBORGeneratorSizer cborGeneratorSizer(CBORFactorySizer f,
-            ByteArrayOutputStream result)
-        throws IOException
-    {
+    protected CBORGeneratorSizer cborGeneratorSizer(CBORFactorySizer f, ByteArrayOutputStream result)
+            throws IOException {
         return f.createGenerator(result, null);
     }
 }
-
-   

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORTestBaseSizer.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORTestBaseSizer.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import com.fasterxml.jackson.dataformat.cbor.CBORParser;
 import com.fasterxml.jackson.dataformat.cbor.CBORTestBase;
 import com.fasterxml.jackson.dataformat.cbor.sizer.CBORFactorySizer;
@@ -40,6 +41,7 @@ public abstract class CBORTestBaseSizer extends CBORTestBase {
 
     protected CBORFactorySizer cborFactorySizer() {
         CBORFactorySizer f = new CBORFactorySizer();
+        f.disable(CBORGenerator.Feature.WRITE_TYPE_HEADER);
         return f;
     }
 

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORTestBaseSizer.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/CBORTestBaseSizer.java
@@ -1,0 +1,83 @@
+package com.fasterxml.jackson.dataformat.cbor.sizer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORParser;
+import com.fasterxml.jackson.dataformat.cbor.CBORTestBase;
+import com.fasterxml.jackson.dataformat.cbor.sizer.CBORFactorySizer;
+
+public abstract class CBORTestBaseSizer extends CBORTestBase
+{
+	 /*
+    /**********************************************************
+    /* Factory methods
+    /**********************************************************
+     */
+  
+    @Override
+	protected CBORParser cborParser(byte[] input) throws IOException {
+        return cborParser(cborFactorySizer(), input);
+    }
+
+    @Override
+	protected CBORParser cborParser(InputStream in) throws IOException {
+        CBORFactorySizer f = cborFactorySizer();
+        return cborParser(f, in);
+    }
+
+    protected CBORParser cborParser(CBORFactorySizer f, byte[] input) throws IOException {
+        return f.createParser(input);
+    }
+    
+	protected CBORParser cborParser(CBORFactorySizer f, InputStream in) throws IOException {
+        return f.createParser(in);
+    }
+    
+    @Override
+	protected ObjectMapper cborMapper() {
+        return new ObjectMapper(cborFactorySizer());
+    } 
+     
+	protected CBORFactorySizer cborFactorySizer() {
+        CBORFactorySizer f = new CBORFactorySizer();
+        return f;
+    }
+    
+    @Override
+	protected byte[] cborDoc(String json) throws IOException {
+        return cborDoc(cborFactorySizer(), json);
+    }
+
+	protected byte[] cborDoc(CBORFactorySizer cborF, String json) throws IOException
+    {
+        JsonFactory jf = new JsonFactory();
+        JsonParser jp = jf.createParser(json);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(json.length());
+        JsonGenerator dest = cborF.createGenerator(out);
+    	
+        while (jp.nextToken() != null) {
+        	dest.copyCurrentEvent(jp);
+        }
+        jp.close();
+        dest.close();
+        return out.toByteArray();
+    }
+
+	protected CBORGeneratorSizer cborGeneratorSizer(ByteArrayOutputStream result)
+        throws IOException
+    {
+        return cborGeneratorSizer(cborFactorySizer(), result);
+    }
+
+	protected CBORGeneratorSizer cborGeneratorSizer(CBORFactorySizer f,
+            ByteArrayOutputStream result)
+        throws IOException
+    {
+        return f.createGenerator(result, null);
+    }
+}
+
+   

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/GeneratorSizerTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/GeneratorSizerTest.java
@@ -7,825 +7,664 @@ import java.math.BigInteger;
 
 import com.fasterxml.jackson.dataformat.cbor.CBORConstants;
 
-public class GeneratorSizerTest extends CBORTestBaseSizer
-{    
+public class GeneratorSizerTest extends CBORTestBaseSizer {
     /**
      * Tests
      */
-    public void testArray_less31elt() throws Exception
-    {
-    	// Test arrays with less of 31 element
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber(1); 
-    	gen.writeNumber(2);
-    	gen.writeNumber(3);
-    	gen.writeEndArray();    	
-    	gen.close();
-	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 3),	// # array(3)
-                (byte) 0x01, 									// # unsigned(1)
-                (byte) 0x02,  									// # unsigned(2)
-                (byte) 0x03); 									// # unsigned(3)
+    public void testArray_less31elt() throws Exception {
+        // Test arrays with less of 31 element
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber(1);
+        gen.writeNumber(2);
+        gen.writeNumber(3);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 3), (byte) 0x01, (byte) 0x02,
+                (byte) 0x03);
     }
-    
-    public void testArray_more31elt() throws Exception
-    {
+
+    public void testArray_more31elt() throws Exception {
         // Test arrays with more of 31 elements
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	
-    	for(int i=1; i<=32; i++){
-    		gen.writeNumber(i % 16);
-    	}
-    	
-    	gen.writeEndArray();    	
-    	gen.close();
-    	  
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.BYTE_ARRAY_INDEFINITE),
-                (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05, (byte) 0x06, (byte) 0x07, 
-                (byte) 0x08, (byte) 0x09, (byte) 0x0A, (byte) 0x0B, (byte) 0x0C, (byte) 0x0D, (byte) 0x0E, 
-                (byte) 0x0F, (byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05, 
-                (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0A, (byte) 0x0B, (byte) 0x0C, 
-                (byte) 0x0D, (byte) 0x0E, (byte) 0x0F, (byte) 0x00, 
-                CBORConstants.BYTE_BREAK);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+
+        for (int i = 1; i <= 32; i++) {
+            gen.writeNumber(i % 16);
+        }
+
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.BYTE_ARRAY_INDEFINITE), (byte) 0x01, (byte) 0x02,
+                (byte) 0x03, (byte) 0x04, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0A,
+                (byte) 0x0B, (byte) 0x0C, (byte) 0x0D, (byte) 0x0E, (byte) 0x0F, (byte) 0x00, (byte) 0x01, (byte) 0x02,
+                (byte) 0x03, (byte) 0x04, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0A,
+                (byte) 0x0B, (byte) 0x0C, (byte) 0x0D, (byte) 0x0E, (byte) 0x0F, (byte) 0x00, CBORConstants.BYTE_BREAK);
     }
-    
-    public void  testMap_less31elt() throws Exception
-    {
-    	// Test map with less of 31 elements
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartObject();
-    	gen.writeFieldName("Fun");
-    	gen.writeBoolean(true);
-    	gen.writeFieldName("Amt");
-    	gen.writeNumber(-2);
-    	gen.writeEndObject();
-    	gen.close();
-    	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_OBJECT + 2),		// # map(2)
-                (byte) 0x63,									    // # text(3)
-                (byte) 0x46, (byte) 0x75, (byte) 0x6e, 				// # "Fun"
-                (byte) 0xf5,        								// # primitive(true)
-                (byte) 0x63,        								// # text(3)
-                (byte) 0x41, (byte) 0x6d, (byte) 0x74, 				// # "Amt"
-                (byte) 0x21);        								// # negative(1)
+
+    public void testMap_less31elt() throws Exception {
+        // Test map with less of 31 elements
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartObject();
+        gen.writeFieldName("Fun");
+        gen.writeBoolean(true);
+        gen.writeFieldName("Amt");
+        gen.writeNumber(-2);
+        gen.writeEndObject();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_OBJECT + 2), (byte) 0x63, (byte) 0x46,
+                (byte) 0x75, (byte) 0x6e, (byte) 0xf5, (byte) 0x63, (byte) 0x41, (byte) 0x6d, (byte) 0x74, (byte) 0x21);
     }
-        
-    public void  testMap_more31elt() throws Exception
-    {
+
+    public void testMap_more31elt() throws Exception {
         // Test map with more of 31 elements
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartObject();
-        for(int i=1; i<=32; i++)
-        {
-        	gen.writeFieldName(Integer.toString(i % 10));
-        	gen.writeNumber(i % 10);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartObject();
+        for (int i = 1; i <= 32; i++) {
+            gen.writeFieldName(Integer.toString(i % 10));
+            gen.writeNumber(i % 10);
         }
         gen.writeEndObject();
         gen.close();
-        
-        assertEquals((out.toByteArray())[0]								, CBORConstants.BYTE_OBJECT_INDEFINITE);
-        assertEquals((out.toByteArray())[out.toByteArray().length - 1]	, CBORConstants.BYTE_BREAK);
-        
-        for(int i=1; i<(out.toByteArray().length - 2) / 3; i=i+3)
-        {
-        	assertEquals((char) 0x61, (out.toByteArray())[i]);												// # text(1)
-        	assertEquals((out.toByteArray())[i+1], (Integer.toString(((i / 3) + 1) % 10)).getBytes()[0]);	// "x"
-        	assertEquals((out.toByteArray())[i+2], (char) ((i / 3) + 1) % 10);								// unsigned(x)
-        } 
-    }
-    
-    public void testNestedArrays() throws Exception
-    {
-        // Test nested arrays.
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber(1);
-    	gen.writeNumber(2);
-    	gen.writeStartArray();
-    	gen.writeNumber(3);
-    	gen.writeNumber(4);
-    	gen.writeEndArray(); 
-    	gen.writeNumber(5);
-    	gen.writeEndArray();    	
-    	gen.close();
-  	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 4),	// # array(4)
-                (byte) 0x01, 									// # unsigned(1)
-                (byte) 0x02,  									// # unsigned(2)
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 2),	// 		# array(2)
-                (byte) 0x03, 									// 		# unsigned(3)
-                (byte) 0x04, 									// 		# unsigned(4)
-                (byte) 0x05); 									// # unsigned(5)
-    }
-       
-    public void testNestedMap() throws Exception
-    {
-     // Test nested maps
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartObject();
-    	gen.writeFieldName("F1");
-    	gen.writeNumber(1);
-    	gen.writeFieldName("F2");
-    	gen.writeNumber(2);
-    	gen.writeFieldName("Sub");
-    	gen.writeStartObject();
-    	gen.writeFieldName("F3");
-    	gen.writeNumber(3);
-    	gen.writeFieldName("F4");
-    	gen.writeNumber(4);
-    	gen.writeEndObject();
-    	gen.writeFieldName("F5");
-    	gen.writeNumber(5);
-    	gen.writeEndObject();
-    	gen.close();
-    	    	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_OBJECT + 4),		// # map(2)
-                (byte) 0x62,									    // # text(2)
-                (byte) 0x46, (byte) 0x31,							// # "F1"
-                (byte) 0x01,        								// # unsigned(1)
-                (byte) 0x62,									    // # text(2)
-                (byte) 0x46, (byte) 0x32,							// # "F2"
-                (byte) 0x02,        								// # unsigned(2)
-                (byte) 0x63,        								// # text(3)
-                (byte) 0x53, (byte) 0x75, (byte) 0x62, 				// # "Sub"
-                (byte) 0xA2,       									// 		# map(2)
-                (byte) 0x62,									    // 		# text(2)
-                (byte) 0x46, (byte) 0x33,							// 		# "F3"
-                (byte) 0x03,        								// 		# unsigned(3)
-                (byte) 0x62,									    // 		# text(2)
-                (byte) 0x46, (byte) 0x34,							// 		# "F4"
-                (byte) 0x04,        								// 		# unsigned(4)
-                (byte) 0x62,									    // # text(2)
-                (byte) 0x46, (byte) 0x35,							// # "F5"
-                (byte) 0x05);        								// # unsigned(5)
-    }
-        
-    public void testNestedMapAndArray() throws Exception
-    {
-        // Test map nested in array and reciprocally
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber(1);
-    	gen.writeString("Str");
-    	gen.writeStartObject();
-    	gen.writeFieldName("Int");
-    	gen.writeNumber(2);
-    	gen.writeFieldName("Bool");
-    	gen.writeBoolean(true);
-    	gen.writeFieldName("Array");    	
-    	gen.writeStartArray();
-    	gen.writeNumber(3);
-    	gen.writeNumber(4);
-    	gen.writeEndArray(); 
-    	gen.writeEndObject();
-    	gen.writeString("Str2");
-    	gen.writeEndArray();    	
-    	gen.close();
-    	        
-    	_verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 4),						// # array(4)
-                (byte) 0x01,               											// # unsigned(1)
-                (byte) 0x63,               											// # text(3)
-                (byte) 0x53, (byte) 0x74, (byte) 0x72,        						// # "Str"
-                (byte) 0xa3,               											// # map(3)
-                (byte) 0x63,            											// 		# text(3)
-    			(byte) 0x49, (byte) 0x6e, (byte) 0x74,     	 						//		# "Int"
-    			(byte) 0x02,            											//		# unsigned(2)
-    			(byte) 0x64,          												//		# text(4)
-    			(byte) 0x42, (byte) 0x6f, (byte) 0x6f, (byte) 0x6c,   				//		# "Bool"
-    			(byte) 0xf5,           												//		# boolean(true)
-    			(byte) 0x65,            											//		# text(5)
-    			(byte) 0x41, (byte) 0x72, (byte) 0x72, (byte) 0x61, (byte) 0x79, 	//		# "Array"
-    			(byte) 0x82,            											//		# array(2)
-    			(byte) 0x03,         												//			# unsigned(3)
-    			(byte) 0x04,         												//			# unsigned(4)
-    			(byte) 0x64,               											// # text(4)
-    			(byte) 0x53, (byte) 0x74, (byte) 0x72, (byte) 0x32);      			// # "Str2"
-    }
-    
-    public void  testStringType_Str_queuingEnabled() throws Exception
-    {
-    	// Test writeString(String text) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	String valueStr = "Test";
-    	gen.writeStartArray();
-    	gen.writeString(valueStr);
-    	gen.writeEndArray();    	
-    	gen.close();
-  	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
-                (byte) 0x64,											// # text(4)
-                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
-    }
-  
-    public void  testStringType_Str_queuingDisabled() throws Exception
-    {
-    	// Test writeString(String text) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	String valueStr = "Test";
-    	gen.writeString(valueStr); 	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0x64,											// # text(4)
-                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
-    }
-       
-    public void  testStringType_CharO_queuingEnabled() throws Exception
-    {
-        // Test writeString(char[] text, int offset, int len) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	char[] valueChar = {'T', 'e', 's', 't'};
-    	gen.writeStartArray();
-    	gen.writeString(valueChar, 0, 4);
-    	gen.writeEndArray();    	
-    	gen.close();
-    	 	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
-                (byte) 0x64,											// # text(4)
-                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"    	
-    }
-    
-    public void  testStringType_CharO_queuingDisabled() throws Exception
-    {   
-        // Test writeString(char[] text, int offset, int len) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	char[] valueChar = {'T', 'e', 's', 't'};
-    	gen.writeString(valueChar, 0, 4);  	
-    	gen.close();
-    	 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0x64,											// # text(4)
-                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"        
-    }
-    
-    public void  testStringType_ByteO_queuingEnabled() throws Exception
-    {
-        // Test writeRawUTF8String(byte[] text, int offset, int length) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	byte[] valueCharUtf8 = "Test".getBytes();
-    	gen.writeStartArray();
-    	gen.writeRawUTF8String(valueCharUtf8, 0, 4);
-    	gen.writeEndArray();    	
-    	gen.close();
-    	 	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
-                (byte) 0x64,											// # text(4)
-                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
-    }
-    
-    public void  testStringType_ByteO_queuingDisabled() throws Exception
-    {
-        // Test writeRawUTF8String(byte[] text, int offset, int length) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
 
-    	byte[] valueCharUtf8 = "Test".getBytes();
-    	gen.writeRawUTF8String(valueCharUtf8, 0, 4);	
-    	gen.close();
-    	  	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0x64,											// # text(4)
-                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
+        assertEquals((out.toByteArray())[0], CBORConstants.BYTE_OBJECT_INDEFINITE);
+        assertEquals((out.toByteArray())[out.toByteArray().length - 1], CBORConstants.BYTE_BREAK);
+
+        for (int i = 1; i < (out.toByteArray().length - 2) / 3; i = i + 3) {
+            assertEquals((char) 0x61, (out.toByteArray())[i]);
+            assertEquals((out.toByteArray())[i + 1], (Integer.toString(((i / 3) + 1) % 10)).getBytes()[0]);
+            assertEquals((out.toByteArray())[i + 2], (char) ((i / 3) + 1) % 10);
+        }
     }
-    
-    public void  testStringType_ByteArray_queuingEnabled() throws Exception
-    {
-        // Test writeUTF8String(byte[] text, int offset, int length) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	byte[] valueCharUtf8 = "Test".getBytes();
-    	gen.writeStartArray();
-    	gen.writeUTF8String(valueCharUtf8, 0, 4);
-    	gen.writeEndArray();    	
-    	gen.close();
-    	 	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
-                (byte) 0x64,											// # text(4)
-                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
+
+    public void testNestedArrays() throws Exception {
+        // Test nested arrays.
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber(1);
+        gen.writeNumber(2);
+        gen.writeStartArray();
+        gen.writeNumber(3);
+        gen.writeNumber(4);
+        gen.writeEndArray();
+        gen.writeNumber(5);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 4), (byte) 0x01, (byte) 0x02,
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 2), (byte) 0x03, (byte) 0x04, (byte) 0x05);
     }
-    
-    public void  testStringType_ByteArray_queuingDisabled() throws Exception
-    {
-        // Test writeUTF8String(byte[] text, int offset, int length) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	byte[] valueCharUtf8 = "Test".getBytes();
-    	gen.writeUTF8String(valueCharUtf8, 0, 4); 	
-    	gen.close();
-    	 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0x64,											// # text(4)
-                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
+
+    public void testNestedMap() throws Exception {
+        // Test nested maps
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartObject();
+        gen.writeFieldName("F1");
+        gen.writeNumber(1);
+        gen.writeFieldName("F2");
+        gen.writeNumber(2);
+        gen.writeFieldName("Sub");
+        gen.writeStartObject();
+        gen.writeFieldName("F3");
+        gen.writeNumber(3);
+        gen.writeFieldName("F4");
+        gen.writeNumber(4);
+        gen.writeEndObject();
+        gen.writeFieldName("F5");
+        gen.writeNumber(5);
+        gen.writeEndObject();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_OBJECT + 4),
+
+                (byte) 0x62, (byte) 0x46, (byte) 0x31, (byte) 0x01, (byte) 0x62, (byte) 0x46, (byte) 0x32, (byte) 0x02,
+                (byte) 0x63, (byte) 0x53, (byte) 0x75, (byte) 0x62, (byte) 0xA2, (byte) 0x62, (byte) 0x46, (byte) 0x33,
+                (byte) 0x03, (byte) 0x62, (byte) 0x46, (byte) 0x34, (byte) 0x04, (byte) 0x62, (byte) 0x46, (byte) 0x35,
+                (byte) 0x05);
     }
-    
-    public void testNumberType_int_queuingEnabled() throws IOException 
-    {
-    	// Test writeNumber(int v) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber(Integer.MAX_VALUE);
-    	gen.writeEndArray();    	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
-                (byte) 0x1A,											// # Unsigned
-                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # int max value
+
+    public void testNestedMapAndArray() throws Exception {
+        // Test map nested in array and reciprocally
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber(1);
+        gen.writeString("Str");
+        gen.writeStartObject();
+        gen.writeFieldName("Int");
+        gen.writeNumber(2);
+        gen.writeFieldName("Bool");
+        gen.writeBoolean(true);
+        gen.writeFieldName("Array");
+        gen.writeStartArray();
+        gen.writeNumber(3);
+        gen.writeNumber(4);
+        gen.writeEndArray();
+        gen.writeEndObject();
+        gen.writeString("Str2");
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 4),
+
+                (byte) 0x01, (byte) 0x63, (byte) 0x53, (byte) 0x74, (byte) 0x72, (byte) 0xa3, (byte) 0x63, (byte) 0x49,
+                (byte) 0x6e, (byte) 0x74, (byte) 0x02, (byte) 0x64, (byte) 0x42, (byte) 0x6f, (byte) 0x6f, (byte) 0x6c,
+                (byte) 0xf5, (byte) 0x65, (byte) 0x41, (byte) 0x72, (byte) 0x72, (byte) 0x61, (byte) 0x79, (byte) 0x82,
+                (byte) 0x03, (byte) 0x04, (byte) 0x64, (byte) 0x53, (byte) 0x74, (byte) 0x72, (byte) 0x32);
     }
-    
-    public void testNumberType_int_queuingDisabled() throws IOException 
-    {
-    	// Test writeNumber(int v) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeNumber(Integer.MAX_VALUE); 	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0x1A,											// # Unsigned
-                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # int max value
+
+    public void testStringType_Str_queuingEnabled() throws Exception {
+        // Test writeString(String text) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        String valueStr = "Test";
+        gen.writeStartArray();
+        gen.writeString(valueStr);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0x64, (byte) 0x54,
+                (byte) 0x65, (byte) 0x73, (byte) 0x74);
     }
-    
-    public void testNumberType_long_queuingEnabled() throws IOException 
-    {
-    	// Test writeNumber(long v) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber(Long.MAX_VALUE);
-    	gen.writeEndArray();    	
-    	gen.close();
-	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
-                (byte) 0x1B,											// # Unsigned
-                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
-                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # long max value
+
+    public void testStringType_Str_queuingDisabled() throws Exception {
+        // Test writeString(String text) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        String valueStr = "Test";
+        gen.writeString(valueStr);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0x64, (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);
     }
-    
-    public void testNumberType_long_queuingDisabled() throws IOException 
-    {
-    	// Test writeNumber(long v) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeNumber(Long.MAX_VALUE);   	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0x1B,											// # Unsigned
-                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
-                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # long max value
+
+    public void testStringType_CharO_queuingEnabled() throws Exception {
+        // Test writeString(char[] text, int offset, int len) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        char[] valueChar = { 'T', 'e', 's', 't' };
+        gen.writeStartArray();
+        gen.writeString(valueChar, 0, 4);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0x64, (byte) 0x54,
+                (byte) 0x65, (byte) 0x73, (byte) 0x74);
     }
-    
-    public void testNumberType_BigInteger_queuingEnabled() throws IOException 
-    {
-    	// Test writeNumber(BigInteger v) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber(BigInteger.ONE);
-    	gen.writeEndArray();    	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
-                (byte) 0xC2,											// # tag(2) - Positive bignum
-                (byte) 0x41,											// # bytes(1)
-                (byte) 0x01);											// # \x01
+
+    public void testStringType_CharO_queuingDisabled() throws Exception {
+        // Test writeString(char[] text, int offset, int len) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        char[] valueChar = { 'T', 'e', 's', 't' };
+        gen.writeString(valueChar, 0, 4);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0x64, (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);
     }
-    
-    public void testNumberType_BigInteger_queuingDisabled() throws IOException 
-    {
-    	// Test writeNumber(BigInteger v) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeNumber(BigInteger.ONE); 	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0xC2,											// # tag(2) - Positive bignum
-                (byte) 0x41,											// # bytes(1)
-                (byte) 0x01);											// # \x01
+
+    public void testStringType_ByteO_queuingEnabled() throws Exception {
+        // Test writeRawUTF8String(byte[] text, int offset, int length) -
+        // queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        byte[] valueCharUtf8 = "Test".getBytes();
+        gen.writeStartArray();
+        gen.writeRawUTF8String(valueCharUtf8, 0, 4);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0x64, (byte) 0x54,
+                (byte) 0x65, (byte) 0x73, (byte) 0x74);
     }
-    
-    public void testNumberType_double_queuingEnabled() throws IOException 
-    {
-    	// Test writeNumber(double v) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber(Double.MAX_VALUE);
-    	gen.writeEndArray();    	
-    	gen.close();
-	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
-                (byte) 0xFB,											
-                (byte) 0x7F, (byte) 0xEF, (byte) 0xFF, (byte) 0xFF,
-                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # double max value
+
+    public void testStringType_ByteO_queuingDisabled() throws Exception {
+        // Test writeRawUTF8String(byte[] text, int offset, int length) -
+        // queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        byte[] valueCharUtf8 = "Test".getBytes();
+        gen.writeRawUTF8String(valueCharUtf8, 0, 4);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0x64, (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);
     }
-    
-    public void testNumberType_double_queuingDisabled() throws IOException 
-    {
-    	// Test writeNumber(double v) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeNumber(Double.MAX_VALUE);  	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0xFB,											
-                (byte) 0x7F, (byte) 0xEF, (byte) 0xFF, (byte) 0xFF,
-                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # double max value
+
+    public void testStringType_ByteArray_queuingEnabled() throws Exception {
+        // Test writeUTF8String(byte[] text, int offset, int length) - queuing
+        // enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        byte[] valueCharUtf8 = "Test".getBytes();
+        gen.writeStartArray();
+        gen.writeUTF8String(valueCharUtf8, 0, 4);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0x64, (byte) 0x54,
+                (byte) 0x65, (byte) 0x73, (byte) 0x74);
     }
-    
-    public void testNumberType_float_queuingEnabled() throws IOException 
-    {
-    	// Test writeNumber(float v) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber(Float.MAX_VALUE);
-    	gen.writeEndArray();    	
-    	gen.close();
-	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
-                (byte) 0xFA,											
-                (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF);	// # float max value
+
+    public void testStringType_ByteArray_queuingDisabled() throws Exception {
+        // Test writeUTF8String(byte[] text, int offset, int length) - queuing
+        // disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        byte[] valueCharUtf8 = "Test".getBytes();
+        gen.writeUTF8String(valueCharUtf8, 0, 4);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0x64, (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);
     }
-    
-    public void testNumberType_float_queuingDisabled() throws IOException 
-    {
-    	// Test writeNumber(float v) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeNumber(Float.MAX_VALUE);  	
-    	gen.close();
-  	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0xFA,											
-                (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF);	// # float max value
+
+    public void testNumberType_int_queuingEnabled() throws IOException {
+        // Test writeNumber(int v) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber(Integer.MAX_VALUE);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0x1A, (byte) 0x7F,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);
     }
-    
-    public void testNumberType_BigDecimal_queuingEnabled() throws IOException 
-    {
-    	// Test writeNumber(BigDecimal v) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber(BigDecimal.TEN);
-    	gen.writeEndArray();    	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
-                (byte) 0xC5,											// # tag(5) - BigFloat
-                (byte) 0x82,											// # array(2)
-                (byte) 0x00,											// Unsigned(0)
-                (byte) 0x0A);											// Unsigned(10)
+
+    public void testNumberType_int_queuingDisabled() throws IOException {
+        // Test writeNumber(int v) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeNumber(Integer.MAX_VALUE);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0x1A, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);
     }
-    
-    public void testNumberType_BigDecimal_queuingDisabled() throws IOException 
-    {
-    	// Test writeNumber(BigDecimal v) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeNumber(BigDecimal.TEN);	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0xC5,											// # tag(5) - BigFloat
-                (byte) 0x82,											// # array(2)
-                (byte) 0x00,											// Unsigned(0)
-                (byte) 0x0A);											// Unsigned(10)
+
+    public void testNumberType_long_queuingEnabled() throws IOException {
+        // Test writeNumber(long v) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber(Long.MAX_VALUE);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0x1B, (byte) 0x7F,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);
     }
-    
-    public void testNumberType_String_queuingEnabled() throws IOException 
-    {
-    	// Test writeNumber(String v) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNumber("42");
-    	gen.writeEndArray();    	
-    	gen.close();
-	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
-                (byte) 0x62,											// # text(2)
-                (byte) 0x34, (byte) 0x32);								// "42"
+
+    public void testNumberType_long_queuingDisabled() throws IOException {
+        // Test writeNumber(long v) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeNumber(Long.MAX_VALUE);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0x1B, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);
     }
-    
-    public void testNumberType_String_queuingDisabled() throws IOException 
-    {
-    	// Test writeNumber(String v) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeNumber("42");   	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0x62,											// # text(2)
-                (byte) 0x34, (byte) 0x32);								// "42"
+
+    public void testNumberType_BigInteger_queuingEnabled() throws IOException {
+        // Test writeNumber(BigInteger v) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber(BigInteger.ONE);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0xC2, (byte) 0x41,
+                (byte) 0x01);
     }
-    
-    public void testBooleanType_queuingEnabled() throws IOException 
-    {
-    	// Test writeBoolean(boolean state) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeBoolean(true);
-    	gen.writeEndArray();    	
-    	gen.close();
-	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
-                (byte) 0xF5);											// # true
+
+    public void testNumberType_BigInteger_queuingDisabled() throws IOException {
+        // Test writeNumber(BigInteger v) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeNumber(BigInteger.ONE);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0xC2, (byte) 0x41, (byte) 0x01);
     }
-    
-    public void testBooleanType_queuingDisabled() throws IOException 
-    {
-    	// Test writeBoolean(boolean state) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeBoolean(true);   	
-    	gen.close();
-	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0xF5);											// # true
+
+    public void testNumberType_double_queuingEnabled() throws IOException {
+        // Test writeNumber(double v) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber(Double.MAX_VALUE);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0xFB, (byte) 0x7F,
+                (byte) 0xEF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);
     }
-    
-    public void testNull_queuingEnabled() throws IOException 
-    {
-    	// Test writeNull() - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeNull();
-    	gen.writeEndArray();    	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
-                (byte) 0xF6);											// # null
+
+    public void testNumberType_double_queuingDisabled() throws IOException {
+        // Test writeNumber(double v) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeNumber(Double.MAX_VALUE);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0xFB, (byte) 0x7F, (byte) 0xEF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);
     }
-    
-    public void testNull_queuingDisabled() throws IOException 
-    {
-    	// Test writeNull() - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeNull();   	
-    	gen.close();
-	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0xF6);											// # null
+
+    public void testNumberType_float_queuingEnabled() throws IOException {
+        // Test writeNumber(float v) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber(Float.MAX_VALUE);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0xFA, (byte) 0x7F,
+                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF);
     }
-    
-    public void testTag_queuingEnabled() throws IOException
-    {
-    	// Test writeTag(int tagId) - queuing enabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeStartArray();
-    	gen.writeTag(1);
-    	gen.writeEndArray();  	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
-                (byte) 0xC1);											// # tag(1)
+
+    public void testNumberType_float_queuingDisabled() throws IOException {
+        // Test writeNumber(float v) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeNumber(Float.MAX_VALUE);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0xFA, (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF);
     }
-    
-    public void testTag_queuingDisabled() throws IOException
-    {
-    	// Test writeTag(int tagId) - queuing disabled
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.writeTag(1); 	
-    	gen.close();
- 	
-        _verifyBytes(out.toByteArray(),
-                (byte) 0xC1);											// # tag(1)
+
+    public void testNumberType_BigDecimal_queuingEnabled() throws IOException {
+        // Test writeNumber(BigDecimal v) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber(BigDecimal.TEN);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0xC5, (byte) 0x82,
+                (byte) 0x00, (byte) 0x0A);
     }
-    
-    public void testWrappedMethod() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	gen.flush();
+
+    public void testNumberType_BigDecimal_queuingDisabled() throws IOException {
+        // Test writeNumber(BigDecimal v) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeNumber(BigDecimal.TEN);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0xC5, (byte) 0x82, (byte) 0x00, (byte) 0x0A);
     }
-    
-    public void testUnsupportedMethods_RawChar_queuingEnabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-        	gen.writeStartArray();
-    		gen.writeRaw('A');
-        	gen.writeEndArray(); 
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    	}
+
+    public void testNumberType_String_queuingEnabled() throws IOException {
+        // Test writeNumber(String v) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNumber("42");
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0x62, (byte) 0x34,
+                (byte) 0x32);
     }
-    
-    public void testUnsupportedMethods_RawChar_queuingDisabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-    		gen.writeRaw('A');
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    	}
+
+    public void testNumberType_String_queuingDisabled() throws IOException {
+        // Test writeNumber(String v) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeNumber("42");
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0x62, (byte) 0x34, (byte) 0x32);
     }
-    
-    public void testUnsupportedMethods_RawStr_queuingEnabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-        	gen.writeStartArray();
-    		gen.writeRaw((String) "test");
-        	gen.writeEndArray(); 
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    		// Check the method is not supported
-    	}
+
+    public void testBooleanType_queuingEnabled() throws IOException {
+        // Test writeBoolean(boolean state) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeBoolean(true);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0xF5);
     }
-    
-    public void testUnsupportedMethods_RawStr_queuingDisabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-    		gen.writeRaw((String) "test"); 
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    		// Check the method is not supported
-    	}
+
+    public void testBooleanType_queuingDisabled() throws IOException {
+        // Test writeBoolean(boolean state) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeBoolean(true);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0xF5); // # true
     }
-    
-    public void testUnsupportedMethods_RawStrO_queuingEnabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-        	gen.writeStartArray();
-    		gen.writeRaw((String) "test", 0, 4);
-        	gen.writeEndArray(); 
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    		// Check the method is not supported
-    	}
+
+    public void testNull_queuingEnabled() throws IOException {
+        // Test writeNull() - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeNull();
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0xF6);
     }
-    
-    public void testUnsupportedMethods_RawStrO_queuingDisabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-    		gen.writeRaw((String) "test", 0, 4);
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    		// Check the method is not supported
-    	}
+
+    public void testNull_queuingDisabled() throws IOException {
+        // Test writeNull() - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeNull();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0xF6);
     }
-    
-    public void testUnsupportedMethods_RawValueStrO_queuingEnabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-        	gen.writeStartArray();
-    		gen.writeRawValue((String) "test", 0, 4);
-        	gen.writeEndArray(); 
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    		// Check the method is not supported
-    	}
+
+    public void testTag_queuingEnabled() throws IOException {
+        // Test writeTag(int tagId) - queuing enabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeStartArray();
+        gen.writeTag(1);
+        gen.writeEndArray();
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1), (byte) 0xC1);
     }
-    
-    public void testUnsupportedMethods_RawValueStrO_queuingDisabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-    		gen.writeRawValue((String) "test", 0, 4);
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    		// Check the method is not supported
-    	}
+
+    public void testTag_queuingDisabled() throws IOException {
+        // Test writeTag(int tagId) - queuing disabled
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.writeTag(1);
+        gen.close();
+
+        _verifyBytes(out.toByteArray(), (byte) 0xC1);
     }
-    
-    public void testUnsupportedMethods_RawCharArrayO_queuingEnabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-        	gen.writeStartArray();
-        	char[] valueChar = {'T', 'e', 's', 't'};
-    		gen.writeRaw(valueChar, 0, 4);
-        	gen.writeEndArray(); 
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    		// Check the method is not supported
-    	}
+
+    public void testWrappedMethod() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        gen.flush();
     }
-    
-    public void testUnsupportedMethods_RawCharArrayO_queuingDisabled() throws IOException
-    {
-    	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
-    	
-    	try{
-        	char[] valueChar = {'T', 'e', 's', 't'};
-    		gen.writeRaw(valueChar, 0, 4);
-    		fail("Should thrown not supported exception");
-    	}
-    	catch(UnsupportedOperationException aExp){
-    		// Check the method is not supported
-    	}
+
+    public void testUnsupportedMethods_RawChar_queuingEnabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            gen.writeStartArray();
+            gen.writeRaw('A');
+            gen.writeEndArray();
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+        }
     }
-    
+
+    public void testUnsupportedMethods_RawChar_queuingDisabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            gen.writeRaw('A');
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+        }
+    }
+
+    public void testUnsupportedMethods_RawStr_queuingEnabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            gen.writeStartArray();
+            gen.writeRaw((String) "test");
+            gen.writeEndArray();
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+            // Check the method is not supported
+        }
+    }
+
+    public void testUnsupportedMethods_RawStr_queuingDisabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            gen.writeRaw((String) "test");
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+            // Check the method is not supported
+        }
+    }
+
+    public void testUnsupportedMethods_RawStrO_queuingEnabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            gen.writeStartArray();
+            gen.writeRaw((String) "test", 0, 4);
+            gen.writeEndArray();
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+            // Check the method is not supported
+        }
+    }
+
+    public void testUnsupportedMethods_RawStrO_queuingDisabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            gen.writeRaw((String) "test", 0, 4);
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+            // Check the method is not supported
+        }
+    }
+
+    public void testUnsupportedMethods_RawValueStrO_queuingEnabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            gen.writeStartArray();
+            gen.writeRawValue((String) "test", 0, 4);
+            gen.writeEndArray();
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+            // Check the method is not supported
+        }
+    }
+
+    public void testUnsupportedMethods_RawValueStrO_queuingDisabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            gen.writeRawValue((String) "test", 0, 4);
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+            // Check the method is not supported
+        }
+    }
+
+    public void testUnsupportedMethods_RawCharArrayO_queuingEnabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            gen.writeStartArray();
+            char[] valueChar = { 'T', 'e', 's', 't' };
+            gen.writeRaw(valueChar, 0, 4);
+            gen.writeEndArray();
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+            // Check the method is not supported
+        }
+    }
+
+    public void testUnsupportedMethods_RawCharArrayO_queuingDisabled() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+        try {
+            char[] valueChar = { 'T', 'e', 's', 't' };
+            gen.writeRaw(valueChar, 0, 4);
+            fail("Should thrown not supported exception");
+        } catch (UnsupportedOperationException aExp) {
+            // Check the method is not supported
+        }
+    }
+
 }

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/GeneratorSizerTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/GeneratorSizerTest.java
@@ -1,0 +1,831 @@
+package com.fasterxml.jackson.dataformat.cbor.sizer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import com.fasterxml.jackson.dataformat.cbor.CBORConstants;
+
+public class GeneratorSizerTest extends CBORTestBaseSizer
+{    
+    /**
+     * Tests
+     */
+    public void testArray_less31elt() throws Exception
+    {
+    	// Test arrays with less of 31 element
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber(1); 
+    	gen.writeNumber(2);
+    	gen.writeNumber(3);
+    	gen.writeEndArray();    	
+    	gen.close();
+	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 3),	// # array(3)
+                (byte) 0x01, 									// # unsigned(1)
+                (byte) 0x02,  									// # unsigned(2)
+                (byte) 0x03); 									// # unsigned(3)
+    }
+    
+    public void testArray_more31elt() throws Exception
+    {
+        // Test arrays with more of 31 elements
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	
+    	for(int i=1; i<=32; i++){
+    		gen.writeNumber(i % 16);
+    	}
+    	
+    	gen.writeEndArray();    	
+    	gen.close();
+    	  
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.BYTE_ARRAY_INDEFINITE),
+                (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05, (byte) 0x06, (byte) 0x07, 
+                (byte) 0x08, (byte) 0x09, (byte) 0x0A, (byte) 0x0B, (byte) 0x0C, (byte) 0x0D, (byte) 0x0E, 
+                (byte) 0x0F, (byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05, 
+                (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0A, (byte) 0x0B, (byte) 0x0C, 
+                (byte) 0x0D, (byte) 0x0E, (byte) 0x0F, (byte) 0x00, 
+                CBORConstants.BYTE_BREAK);
+    }
+    
+    public void  testMap_less31elt() throws Exception
+    {
+    	// Test map with less of 31 elements
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartObject();
+    	gen.writeFieldName("Fun");
+    	gen.writeBoolean(true);
+    	gen.writeFieldName("Amt");
+    	gen.writeNumber(-2);
+    	gen.writeEndObject();
+    	gen.close();
+    	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_OBJECT + 2),		// # map(2)
+                (byte) 0x63,									    // # text(3)
+                (byte) 0x46, (byte) 0x75, (byte) 0x6e, 				// # "Fun"
+                (byte) 0xf5,        								// # primitive(true)
+                (byte) 0x63,        								// # text(3)
+                (byte) 0x41, (byte) 0x6d, (byte) 0x74, 				// # "Amt"
+                (byte) 0x21);        								// # negative(1)
+    }
+        
+    public void  testMap_more31elt() throws Exception
+    {
+        // Test map with more of 31 elements
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartObject();
+        for(int i=1; i<=32; i++)
+        {
+        	gen.writeFieldName(Integer.toString(i % 10));
+        	gen.writeNumber(i % 10);
+        }
+        gen.writeEndObject();
+        gen.close();
+        
+        assertEquals((out.toByteArray())[0]								, CBORConstants.BYTE_OBJECT_INDEFINITE);
+        assertEquals((out.toByteArray())[out.toByteArray().length - 1]	, CBORConstants.BYTE_BREAK);
+        
+        for(int i=1; i<(out.toByteArray().length - 2) / 3; i=i+3)
+        {
+        	assertEquals((char) 0x61, (out.toByteArray())[i]);												// # text(1)
+        	assertEquals((out.toByteArray())[i+1], (Integer.toString(((i / 3) + 1) % 10)).getBytes()[0]);	// "x"
+        	assertEquals((out.toByteArray())[i+2], (char) ((i / 3) + 1) % 10);								// unsigned(x)
+        } 
+    }
+    
+    public void testNestedArrays() throws Exception
+    {
+        // Test nested arrays.
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber(1);
+    	gen.writeNumber(2);
+    	gen.writeStartArray();
+    	gen.writeNumber(3);
+    	gen.writeNumber(4);
+    	gen.writeEndArray(); 
+    	gen.writeNumber(5);
+    	gen.writeEndArray();    	
+    	gen.close();
+  	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 4),	// # array(4)
+                (byte) 0x01, 									// # unsigned(1)
+                (byte) 0x02,  									// # unsigned(2)
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 2),	// 		# array(2)
+                (byte) 0x03, 									// 		# unsigned(3)
+                (byte) 0x04, 									// 		# unsigned(4)
+                (byte) 0x05); 									// # unsigned(5)
+    }
+       
+    public void testNestedMap() throws Exception
+    {
+     // Test nested maps
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartObject();
+    	gen.writeFieldName("F1");
+    	gen.writeNumber(1);
+    	gen.writeFieldName("F2");
+    	gen.writeNumber(2);
+    	gen.writeFieldName("Sub");
+    	gen.writeStartObject();
+    	gen.writeFieldName("F3");
+    	gen.writeNumber(3);
+    	gen.writeFieldName("F4");
+    	gen.writeNumber(4);
+    	gen.writeEndObject();
+    	gen.writeFieldName("F5");
+    	gen.writeNumber(5);
+    	gen.writeEndObject();
+    	gen.close();
+    	    	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_OBJECT + 4),		// # map(2)
+                (byte) 0x62,									    // # text(2)
+                (byte) 0x46, (byte) 0x31,							// # "F1"
+                (byte) 0x01,        								// # unsigned(1)
+                (byte) 0x62,									    // # text(2)
+                (byte) 0x46, (byte) 0x32,							// # "F2"
+                (byte) 0x02,        								// # unsigned(2)
+                (byte) 0x63,        								// # text(3)
+                (byte) 0x53, (byte) 0x75, (byte) 0x62, 				// # "Sub"
+                (byte) 0xA2,       									// 		# map(2)
+                (byte) 0x62,									    // 		# text(2)
+                (byte) 0x46, (byte) 0x33,							// 		# "F3"
+                (byte) 0x03,        								// 		# unsigned(3)
+                (byte) 0x62,									    // 		# text(2)
+                (byte) 0x46, (byte) 0x34,							// 		# "F4"
+                (byte) 0x04,        								// 		# unsigned(4)
+                (byte) 0x62,									    // # text(2)
+                (byte) 0x46, (byte) 0x35,							// # "F5"
+                (byte) 0x05);        								// # unsigned(5)
+    }
+        
+    public void testNestedMapAndArray() throws Exception
+    {
+        // Test map nested in array and reciprocally
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber(1);
+    	gen.writeString("Str");
+    	gen.writeStartObject();
+    	gen.writeFieldName("Int");
+    	gen.writeNumber(2);
+    	gen.writeFieldName("Bool");
+    	gen.writeBoolean(true);
+    	gen.writeFieldName("Array");    	
+    	gen.writeStartArray();
+    	gen.writeNumber(3);
+    	gen.writeNumber(4);
+    	gen.writeEndArray(); 
+    	gen.writeEndObject();
+    	gen.writeString("Str2");
+    	gen.writeEndArray();    	
+    	gen.close();
+    	        
+    	_verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 4),						// # array(4)
+                (byte) 0x01,               											// # unsigned(1)
+                (byte) 0x63,               											// # text(3)
+                (byte) 0x53, (byte) 0x74, (byte) 0x72,        						// # "Str"
+                (byte) 0xa3,               											// # map(3)
+                (byte) 0x63,            											// 		# text(3)
+    			(byte) 0x49, (byte) 0x6e, (byte) 0x74,     	 						//		# "Int"
+    			(byte) 0x02,            											//		# unsigned(2)
+    			(byte) 0x64,          												//		# text(4)
+    			(byte) 0x42, (byte) 0x6f, (byte) 0x6f, (byte) 0x6c,   				//		# "Bool"
+    			(byte) 0xf5,           												//		# boolean(true)
+    			(byte) 0x65,            											//		# text(5)
+    			(byte) 0x41, (byte) 0x72, (byte) 0x72, (byte) 0x61, (byte) 0x79, 	//		# "Array"
+    			(byte) 0x82,            											//		# array(2)
+    			(byte) 0x03,         												//			# unsigned(3)
+    			(byte) 0x04,         												//			# unsigned(4)
+    			(byte) 0x64,               											// # text(4)
+    			(byte) 0x53, (byte) 0x74, (byte) 0x72, (byte) 0x32);      			// # "Str2"
+    }
+    
+    public void  testStringType_Str_queuingEnabled() throws Exception
+    {
+    	// Test writeString(String text) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	String valueStr = "Test";
+    	gen.writeStartArray();
+    	gen.writeString(valueStr);
+    	gen.writeEndArray();    	
+    	gen.close();
+  	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
+                (byte) 0x64,											// # text(4)
+                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
+    }
+  
+    public void  testStringType_Str_queuingDisabled() throws Exception
+    {
+    	// Test writeString(String text) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	String valueStr = "Test";
+    	gen.writeString(valueStr); 	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x64,											// # text(4)
+                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
+    }
+       
+    public void  testStringType_CharO_queuingEnabled() throws Exception
+    {
+        // Test writeString(char[] text, int offset, int len) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	char[] valueChar = {'T', 'e', 's', 't'};
+    	gen.writeStartArray();
+    	gen.writeString(valueChar, 0, 4);
+    	gen.writeEndArray();    	
+    	gen.close();
+    	 	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
+                (byte) 0x64,											// # text(4)
+                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"    	
+    }
+    
+    public void  testStringType_CharO_queuingDisabled() throws Exception
+    {   
+        // Test writeString(char[] text, int offset, int len) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	char[] valueChar = {'T', 'e', 's', 't'};
+    	gen.writeString(valueChar, 0, 4);  	
+    	gen.close();
+    	 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x64,											// # text(4)
+                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"        
+    }
+    
+    public void  testStringType_ByteO_queuingEnabled() throws Exception
+    {
+        // Test writeRawUTF8String(byte[] text, int offset, int length) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	byte[] valueCharUtf8 = "Test".getBytes();
+    	gen.writeStartArray();
+    	gen.writeRawUTF8String(valueCharUtf8, 0, 4);
+    	gen.writeEndArray();    	
+    	gen.close();
+    	 	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
+                (byte) 0x64,											// # text(4)
+                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
+    }
+    
+    public void  testStringType_ByteO_queuingDisabled() throws Exception
+    {
+        // Test writeRawUTF8String(byte[] text, int offset, int length) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+
+    	byte[] valueCharUtf8 = "Test".getBytes();
+    	gen.writeRawUTF8String(valueCharUtf8, 0, 4);	
+    	gen.close();
+    	  	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x64,											// # text(4)
+                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
+    }
+    
+    public void  testStringType_ByteArray_queuingEnabled() throws Exception
+    {
+        // Test writeUTF8String(byte[] text, int offset, int length) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	byte[] valueCharUtf8 = "Test".getBytes();
+    	gen.writeStartArray();
+    	gen.writeUTF8String(valueCharUtf8, 0, 4);
+    	gen.writeEndArray();    	
+    	gen.close();
+    	 	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
+                (byte) 0x64,											// # text(4)
+                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
+    }
+    
+    public void  testStringType_ByteArray_queuingDisabled() throws Exception
+    {
+        // Test writeUTF8String(byte[] text, int offset, int length) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	byte[] valueCharUtf8 = "Test".getBytes();
+    	gen.writeUTF8String(valueCharUtf8, 0, 4); 	
+    	gen.close();
+    	 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x64,											// # text(4)
+                (byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74);	// # "Test"
+    }
+    
+    public void testNumberType_int_queuingEnabled() throws IOException 
+    {
+    	// Test writeNumber(int v) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber(Integer.MAX_VALUE);
+    	gen.writeEndArray();    	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
+                (byte) 0x1A,											// # Unsigned
+                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # int max value
+    }
+    
+    public void testNumberType_int_queuingDisabled() throws IOException 
+    {
+    	// Test writeNumber(int v) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeNumber(Integer.MAX_VALUE); 	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x1A,											// # Unsigned
+                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # int max value
+    }
+    
+    public void testNumberType_long_queuingEnabled() throws IOException 
+    {
+    	// Test writeNumber(long v) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber(Long.MAX_VALUE);
+    	gen.writeEndArray();    	
+    	gen.close();
+	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
+                (byte) 0x1B,											// # Unsigned
+                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # long max value
+    }
+    
+    public void testNumberType_long_queuingDisabled() throws IOException 
+    {
+    	// Test writeNumber(long v) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeNumber(Long.MAX_VALUE);   	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x1B,											// # Unsigned
+                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # long max value
+    }
+    
+    public void testNumberType_BigInteger_queuingEnabled() throws IOException 
+    {
+    	// Test writeNumber(BigInteger v) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber(BigInteger.ONE);
+    	gen.writeEndArray();    	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
+                (byte) 0xC2,											// # tag(2) - Positive bignum
+                (byte) 0x41,											// # bytes(1)
+                (byte) 0x01);											// # \x01
+    }
+    
+    public void testNumberType_BigInteger_queuingDisabled() throws IOException 
+    {
+    	// Test writeNumber(BigInteger v) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeNumber(BigInteger.ONE); 	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0xC2,											// # tag(2) - Positive bignum
+                (byte) 0x41,											// # bytes(1)
+                (byte) 0x01);											// # \x01
+    }
+    
+    public void testNumberType_double_queuingEnabled() throws IOException 
+    {
+    	// Test writeNumber(double v) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber(Double.MAX_VALUE);
+    	gen.writeEndArray();    	
+    	gen.close();
+	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
+                (byte) 0xFB,											
+                (byte) 0x7F, (byte) 0xEF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # double max value
+    }
+    
+    public void testNumberType_double_queuingDisabled() throws IOException 
+    {
+    	// Test writeNumber(double v) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeNumber(Double.MAX_VALUE);  	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0xFB,											
+                (byte) 0x7F, (byte) 0xEF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF);	// # double max value
+    }
+    
+    public void testNumberType_float_queuingEnabled() throws IOException 
+    {
+    	// Test writeNumber(float v) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber(Float.MAX_VALUE);
+    	gen.writeEndArray();    	
+    	gen.close();
+	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
+                (byte) 0xFA,											
+                (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF);	// # float max value
+    }
+    
+    public void testNumberType_float_queuingDisabled() throws IOException 
+    {
+    	// Test writeNumber(float v) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeNumber(Float.MAX_VALUE);  	
+    	gen.close();
+  	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0xFA,											
+                (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF);	// # float max value
+    }
+    
+    public void testNumberType_BigDecimal_queuingEnabled() throws IOException 
+    {
+    	// Test writeNumber(BigDecimal v) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber(BigDecimal.TEN);
+    	gen.writeEndArray();    	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(3)
+                (byte) 0xC5,											// # tag(5) - BigFloat
+                (byte) 0x82,											// # array(2)
+                (byte) 0x00,											// Unsigned(0)
+                (byte) 0x0A);											// Unsigned(10)
+    }
+    
+    public void testNumberType_BigDecimal_queuingDisabled() throws IOException 
+    {
+    	// Test writeNumber(BigDecimal v) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeNumber(BigDecimal.TEN);	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0xC5,											// # tag(5) - BigFloat
+                (byte) 0x82,											// # array(2)
+                (byte) 0x00,											// Unsigned(0)
+                (byte) 0x0A);											// Unsigned(10)
+    }
+    
+    public void testNumberType_String_queuingEnabled() throws IOException 
+    {
+    	// Test writeNumber(String v) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNumber("42");
+    	gen.writeEndArray();    	
+    	gen.close();
+	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
+                (byte) 0x62,											// # text(2)
+                (byte) 0x34, (byte) 0x32);								// "42"
+    }
+    
+    public void testNumberType_String_queuingDisabled() throws IOException 
+    {
+    	// Test writeNumber(String v) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeNumber("42");   	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x62,											// # text(2)
+                (byte) 0x34, (byte) 0x32);								// "42"
+    }
+    
+    public void testBooleanType_queuingEnabled() throws IOException 
+    {
+    	// Test writeBoolean(boolean state) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeBoolean(true);
+    	gen.writeEndArray();    	
+    	gen.close();
+	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
+                (byte) 0xF5);											// # true
+    }
+    
+    public void testBooleanType_queuingDisabled() throws IOException 
+    {
+    	// Test writeBoolean(boolean state) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeBoolean(true);   	
+    	gen.close();
+	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0xF5);											// # true
+    }
+    
+    public void testNull_queuingEnabled() throws IOException 
+    {
+    	// Test writeNull() - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeNull();
+    	gen.writeEndArray();    	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
+                (byte) 0xF6);											// # null
+    }
+    
+    public void testNull_queuingDisabled() throws IOException 
+    {
+    	// Test writeNull() - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeNull();   	
+    	gen.close();
+	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0xF6);											// # null
+    }
+    
+    public void testTag_queuingEnabled() throws IOException
+    {
+    	// Test writeTag(int tagId) - queuing enabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeStartArray();
+    	gen.writeTag(1);
+    	gen.writeEndArray();  	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_ARRAY + 1),			// # array(1)
+                (byte) 0xC1);											// # tag(1)
+    }
+    
+    public void testTag_queuingDisabled() throws IOException
+    {
+    	// Test writeTag(int tagId) - queuing disabled
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.writeTag(1); 	
+    	gen.close();
+ 	
+        _verifyBytes(out.toByteArray(),
+                (byte) 0xC1);											// # tag(1)
+    }
+    
+    public void testWrappedMethod() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	gen.flush();
+    }
+    
+    public void testUnsupportedMethods_RawChar_queuingEnabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+        	gen.writeStartArray();
+    		gen.writeRaw('A');
+        	gen.writeEndArray(); 
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    	}
+    }
+    
+    public void testUnsupportedMethods_RawChar_queuingDisabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+    		gen.writeRaw('A');
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    	}
+    }
+    
+    public void testUnsupportedMethods_RawStr_queuingEnabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+        	gen.writeStartArray();
+    		gen.writeRaw((String) "test");
+        	gen.writeEndArray(); 
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    		// Check the method is not supported
+    	}
+    }
+    
+    public void testUnsupportedMethods_RawStr_queuingDisabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+    		gen.writeRaw((String) "test"); 
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    		// Check the method is not supported
+    	}
+    }
+    
+    public void testUnsupportedMethods_RawStrO_queuingEnabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+        	gen.writeStartArray();
+    		gen.writeRaw((String) "test", 0, 4);
+        	gen.writeEndArray(); 
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    		// Check the method is not supported
+    	}
+    }
+    
+    public void testUnsupportedMethods_RawStrO_queuingDisabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+    		gen.writeRaw((String) "test", 0, 4);
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    		// Check the method is not supported
+    	}
+    }
+    
+    public void testUnsupportedMethods_RawValueStrO_queuingEnabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+        	gen.writeStartArray();
+    		gen.writeRawValue((String) "test", 0, 4);
+        	gen.writeEndArray(); 
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    		// Check the method is not supported
+    	}
+    }
+    
+    public void testUnsupportedMethods_RawValueStrO_queuingDisabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+    		gen.writeRawValue((String) "test", 0, 4);
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    		// Check the method is not supported
+    	}
+    }
+    
+    public void testUnsupportedMethods_RawCharArrayO_queuingEnabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+        	gen.writeStartArray();
+        	char[] valueChar = {'T', 'e', 's', 't'};
+    		gen.writeRaw(valueChar, 0, 4);
+        	gen.writeEndArray(); 
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    		// Check the method is not supported
+    	}
+    }
+    
+    public void testUnsupportedMethods_RawCharArrayO_queuingDisabled() throws IOException
+    {
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	CBORGeneratorSizer gen = cborGeneratorSizer(out);
+    	
+    	try{
+        	char[] valueChar = {'T', 'e', 's', 't'};
+    		gen.writeRaw(valueChar, 0, 4);
+    		fail("Should thrown not supported exception");
+    	}
+    	catch(UnsupportedOperationException aExp){
+    		// Check the method is not supported
+    	}
+    }
+    
+}

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/ParserSimpleTestSizer.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/ParserSimpleTestSizer.java
@@ -1,0 +1,399 @@
+package com.fasterxml.jackson.dataformat.cbor.sizer;
+
+import java.io.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.JsonParser.NumberType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORConstants;
+import com.fasterxml.jackson.dataformat.cbor.CBORParser;
+
+/**
+ * Unit tests for simple value types.
+ */
+public class ParserSimpleTestSizer extends CBORTestBaseSizer
+{
+    private final ObjectMapper MAPPER = cborMapper();
+    
+    /**
+     * Test for verifying handling of 'true', 'false' and 'null' literals
+     */
+    public void testSimpleLiterals() throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonGenerator gen = cborGeneratorSizer(out);
+        gen.writeBoolean(true);
+        gen.close();
+        JsonParser p = cborParser(out);
+        assertEquals(JsonToken.VALUE_TRUE, p.nextToken());
+        assertNull(p.nextToken());
+        p.close();
+
+        out = new ByteArrayOutputStream();
+        gen = cborGeneratorSizer(out);
+        gen.writeBoolean(false);
+        gen.close();
+        p = cborParser(out);
+        assertEquals(JsonToken.VALUE_FALSE, p.nextToken());
+        assertNull(p.nextToken());
+        p.close();
+
+        out = new ByteArrayOutputStream();
+        gen = cborGeneratorSizer(out);
+        gen.writeNull();
+        gen.close();
+        p = cborParser(out);
+        assertEquals(JsonToken.VALUE_NULL, p.nextToken());
+        assertNull(p.nextToken());
+        p.close();
+    }
+    
+    public void testIntValues() throws Exception
+    {
+        // first, single-byte
+        CBORFactorySizer f = cborFactorySizer();
+        // single byte
+        _verifyInt(f, 13);
+        _verifyInt(f, -19);
+        // two bytes
+        _verifyInt(f, 255);
+        _verifyInt(f, -127);
+        // three
+        _verifyInt(f, 256);
+        _verifyInt(f, 0xFFFF);
+        _verifyInt(f, -300);
+        _verifyInt(f, -0xFFFF);
+        // and all 4 bytes
+        _verifyInt(f, 0x7FFFFFFF);
+        _verifyInt(f, 0x70000000 << 1);
+    }
+
+    private void _verifyInt(CBORFactorySizer f, int value) throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonGenerator gen = cborGeneratorSizer(f, out);
+        gen.writeNumber(value);
+        gen.close();
+        JsonParser p = cborParser(f, out.toByteArray());
+        assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(NumberType.INT, p.getNumberType());
+        assertEquals(value, p.getIntValue());
+        assertEquals((double) value, p.getDoubleValue());
+        assertNull(p.nextToken());
+        p.close();
+    }
+
+    public void testLongValues() throws Exception
+    {
+        CBORFactorySizer f = cborFactorySizer();
+        _verifyLong(f, 1L + Integer.MAX_VALUE);
+        _verifyLong(f, -1L + Integer.MIN_VALUE);
+    }
+
+    private void _verifyLong(CBORFactorySizer f, long value) throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonGenerator gen = cborGeneratorSizer(f, out);
+        gen.writeNumber(value);
+        gen.close();
+        JsonParser p = cborParser(f, out.toByteArray());
+        assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(value, p.getLongValue());
+        assertEquals(NumberType.LONG, p.getNumberType());
+        assertEquals((double) value, p.getDoubleValue());
+        assertNull(p.nextToken());
+        p.close();
+    }
+    
+    public void testFloatValues() throws Exception
+    {
+        // first, single-byte
+        CBORFactorySizer f = cborFactorySizer();
+        // single byte
+        _verifyFloat(f, 0.25);
+        _verifyFloat(f, 20.5);
+
+        // But then, oddity: 16-bit mini-float
+        // Examples from [https://en.wikipedia.org/wiki/Half_precision_floating-point_format]
+        _verifyHalfFloat(f, 0, 0.0);
+        _verifyHalfFloat(f, 0x3C00, 1.0);
+        _verifyHalfFloat(f, 0xC000, -2.0);
+        _verifyHalfFloat(f, 0x7BFF, 65504.0);
+        _verifyHalfFloat(f, 0x7C00, Double.POSITIVE_INFINITY);
+        _verifyHalfFloat(f, 0xFC00, Double.NEGATIVE_INFINITY);
+
+        // ... can add more, but need bit looser comparison if so
+    }
+
+    private void _verifyFloat(CBORFactorySizer f, double value) throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonGenerator gen = cborGeneratorSizer(f, out);
+        gen.writeNumber((float) value);
+        gen.close();
+        JsonParser p = cborParser(f, out.toByteArray());
+        assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        if (NumberType.FLOAT != p.getNumberType()) {
+            fail("Expected `NumberType.FLOAT`, got "+p.getNumberType()+": "+p.getText());
+        }
+        assertEquals(value, p.getDoubleValue());
+        assertNull(p.nextToken());
+        p.close();
+    }
+
+    private void _verifyHalfFloat(JsonFactory f, int i16, double value) throws IOException
+    {
+        JsonParser p = f.createParser(new byte[] {
+                (byte) (CBORConstants.PREFIX_TYPE_MISC + 25),
+                (byte) (i16 >> 8), (byte) i16
+        });
+        assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(NumberType.FLOAT, p.getNumberType());
+        assertEquals(value, p.getDoubleValue());
+        assertNull(p.nextToken());
+        p.close();
+    }
+    
+    public void testSimpleArray() throws Exception
+    {
+        byte[] b = MAPPER.writeValueAsBytes(new int[] { 1, 2, 3, 4});
+        int[] output = MAPPER.readValue(b, int[].class);
+        assertEquals(4, output.length);
+        for (int i = 1; i <= output.length; ++i) {
+            assertEquals(i, output[i-1]);
+        }
+    }
+
+    public void testSimpleObject() throws Exception
+    {
+        Map<String,Object> input = new LinkedHashMap<String,Object>();
+        input.put("a", 1);
+        input.put("bar", "foo");
+        final String NON_ASCII_NAME = "Y\\u00F6";
+        input.put(NON_ASCII_NAME, -3.25);
+        input.put("", "");
+        byte[] b = MAPPER.writeValueAsBytes(input);
+
+        // First, using streaming API
+        JsonParser p = cborParser(b);
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+        assertToken(JsonToken.FIELD_NAME, p.nextToken());
+        assertEquals("a", p.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(1, p.getIntValue());
+
+        assertToken(JsonToken.FIELD_NAME, p.nextToken());
+        assertEquals("bar", p.getCurrentName());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("foo", p.getText());
+
+        assertToken(JsonToken.FIELD_NAME, p.nextToken());
+        assertEquals(NON_ASCII_NAME, p.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(-3.25, p.getDoubleValue());
+
+        assertToken(JsonToken.FIELD_NAME, p.nextToken());
+        assertEquals("", p.getCurrentName());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("", p.getText());
+        
+        assertToken(JsonToken.END_OBJECT, p.nextToken());
+
+        p.close();
+        
+        Map<?,?> output = MAPPER.readValue(b, Map.class);
+        assertEquals(4, output.size());
+        assertEquals(Integer.valueOf(1), output.get("a"));
+        assertEquals("foo", output.get("bar"));
+        assertEquals(Double.valueOf(-3.25), output.get(NON_ASCII_NAME));
+        assertEquals("", output.get(""));
+    }
+
+    public void testMediumText() throws Exception
+    {
+        _testMedium(1100);
+        _testMedium(1300);
+        _testMedium(1900);
+        _testMedium(2300);
+        _testMedium(3900);
+    }
+    
+    private void _testMedium(int len) throws Exception
+    {
+        // First, use size that should fit in output buffer, but
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+        final String MEDIUM = generateUnicodeString(len);
+        gen.writeString(MEDIUM);
+        gen.close();
+
+        final byte[] b = out.toByteArray();
+
+        // verify that it is indeed non-chunked still...
+        assertEquals((byte) (CBORConstants.PREFIX_TYPE_TEXT + 25), b[0]);
+        
+        JsonParser p = cborParser(b);
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals(MEDIUM, p.getText());
+        assertNull(p.nextToken());
+        p.close();
+    }
+
+    public void testCurrentLocationByteOffset() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+        gen.writeString("1234567890");
+        gen.writeString("1234567890");
+        gen.close();
+
+        final byte[] b = out.toByteArray();
+
+        JsonParser p = cborParser(b);
+
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals(1, p.getCurrentLocation().getByteOffset());
+        p.getText(); // fully read token.
+        assertEquals(11, p.getCurrentLocation().getByteOffset());
+
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals(12, p.getCurrentLocation().getByteOffset());
+        p.getText();
+        assertEquals(22, p.getCurrentLocation().getByteOffset());
+
+        assertNull(p.nextToken());
+        assertEquals(22, p.getCurrentLocation().getByteOffset());
+
+        p.close();
+        assertEquals(22, p.getCurrentLocation().getByteOffset());
+    }
+
+    public void testLongNonChunkedText() throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        final String LONG = generateUnicodeString(37000);
+        final byte[] LONG_B = LONG.getBytes("UTF-8");
+        final int BYTE_LEN = LONG_B.length;
+        out.write(CBORConstants.BYTE_ARRAY_INDEFINITE);
+        out.write((byte) (CBORConstants.PREFIX_TYPE_TEXT + 25));
+        out.write((byte) (BYTE_LEN >> 8));
+        out.write((byte) BYTE_LEN);
+        out.write(LONG.getBytes("UTF-8"));
+        out.write(CBORConstants.BYTE_BREAK);
+
+        final byte[] b = out.toByteArray();
+        assertEquals(BYTE_LEN + 5, b.length);
+
+        // Important! Need to construct a stream, to force boundary conditions
+        JsonParser p = cborParser(new ByteArrayInputStream(b));
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        String actual = p.getText();
+
+        final int end = Math.min(LONG.length(), actual.length());
+        for (int i = 0; i < end; ++i) {
+            if (LONG.charAt(i) != actual.charAt(i)) {
+                fail("Character #"+i+" (of "+end+") differs; expected 0x"+Integer.toHexString(LONG.charAt(i))
+                        +" found 0x"+Integer.toHexString(actual.charAt(i)));
+            }
+        }
+        
+        assertEquals(LONG.length(), actual.length());
+        
+        assertEquals(LONG, p.getText());
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+        assertNull(p.nextToken());
+        p.close();
+    }
+    
+    public void testLongChunkedText() throws Exception
+    {
+        // First, try with ASCII content
+        StringBuilder sb = new StringBuilder(21000);
+        for (int i = 0; i < 21000; ++i) {
+            sb.append('Z');
+        }
+        _testLongChunkedText(sb.toString());        
+        // Second, with actual variable byte-length Unicode
+        _testLongChunkedText(generateUnicodeString(21000));
+    }
+        
+    public void _testLongChunkedText(String input) throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer gen = cborGeneratorSizer(out);
+        gen.writeString(input);
+        gen.close();
+
+        final int textByteCount = input.getBytes("UTF-8").length;
+        final byte[] b = out.toByteArray();
+        assertEquals((byte) (CBORConstants.PREFIX_TYPE_TEXT + 0x1F), b[0]);
+        assertEquals(CBORConstants.BYTE_BREAK, b[b.length-1]);
+
+        // First, verify validity by scanning
+        int i = 1;
+        int total = 0;
+
+        for (int end = b.length-1; i < end; ) {
+            int type = b[i++] & 0xFF;
+            int len = type - CBORConstants.PREFIX_TYPE_TEXT;
+
+            if (len < 24) { // tiny, fine
+                ;
+            } else if (len == 24) { // 1-byte
+                len = (b[i++] & 0xFF);
+            } else if (len == 25) { // 2-byte
+                len = ((b[i++] & 0xFF) << 8) + (b[i++] & 0xFF);
+            }
+            i += len;
+            total += len;
+        }
+        assertEquals(b.length-1, i);
+        assertEquals(textByteCount, total);
+
+        JsonParser p;
+
+        // then skipping
+        p = cborParser(new ByteArrayInputStream(b));
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertNull(p.nextToken());
+        p.close();
+        
+        // and then with actual full parsing/access
+        p = cborParser(new ByteArrayInputStream(b));
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        String actual = p.getText();
+        assertNull(p.nextToken());
+        assertEquals(input.length(), actual.length());
+        if (!input.equals(actual)) {
+            i = 0;
+            while (i < input.length() && input.charAt(i) == actual.charAt(i)) { ++i; }
+            fail("Strings differ at #"+i+" (length "+input.length()+"); expected 0x"
+                    +Integer.toHexString(input.charAt(i))+", got 0x"
+                    +Integer.toHexString(actual.charAt(i)));
+        }
+        assertEquals(input, actual);
+        p.close();
+    }
+
+    public void testFloatNumberType() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGeneratorSizer generator = cborGeneratorSizer(out);
+        generator.writeStartObject();
+        generator.writeFieldName("foo");
+        generator.writeNumber(3f);
+        generator.writeEndObject();
+        generator.close();
+
+        CBORParser parser = cborParser(out.toByteArray());
+        assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals(JsonToken.VALUE_NUMBER_FLOAT, parser.nextToken());
+        assertEquals(NumberType.FLOAT, parser.getNumberType()); // fails with expected <FLOAT> but was <DOUBLE>
+        assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+        parser.close();
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/ParserSimpleTestSizer.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/ParserSimpleTestSizer.java
@@ -376,10 +376,8 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer {
         assertEquals(JsonToken.START_OBJECT, parser.nextToken());
         assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
         assertEquals(JsonToken.VALUE_NUMBER_FLOAT, parser.nextToken());
-        assertEquals(NumberType.FLOAT, parser.getNumberType()); // fails with
-                                                                // expected
-                                                                // <FLOAT> but
-                                                                // was <DOUBLE>
+        // fails with expected <FLOAT> but was <DOUBLE>
+        assertEquals(NumberType.FLOAT, parser.getNumberType());
         assertEquals(JsonToken.END_OBJECT, parser.nextToken());
         parser.close();
     }

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/ParserSimpleTestSizer.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/ParserSimpleTestSizer.java
@@ -13,15 +13,13 @@ import com.fasterxml.jackson.dataformat.cbor.CBORParser;
 /**
  * Unit tests for simple value types.
  */
-public class ParserSimpleTestSizer extends CBORTestBaseSizer
-{
+public class ParserSimpleTestSizer extends CBORTestBaseSizer {
     private final ObjectMapper MAPPER = cborMapper();
-    
+
     /**
      * Test for verifying handling of 'true', 'false' and 'null' literals
      */
-    public void testSimpleLiterals() throws Exception
-    {
+    public void testSimpleLiterals() throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         JsonGenerator gen = cborGeneratorSizer(out);
         gen.writeBoolean(true);
@@ -49,9 +47,8 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         assertNull(p.nextToken());
         p.close();
     }
-    
-    public void testIntValues() throws Exception
-    {
+
+    public void testIntValues() throws Exception {
         // first, single-byte
         CBORFactorySizer f = cborFactorySizer();
         // single byte
@@ -70,8 +67,7 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         _verifyInt(f, 0x70000000 << 1);
     }
 
-    private void _verifyInt(CBORFactorySizer f, int value) throws Exception
-    {
+    private void _verifyInt(CBORFactorySizer f, int value) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         JsonGenerator gen = cborGeneratorSizer(f, out);
         gen.writeNumber(value);
@@ -85,15 +81,13 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         p.close();
     }
 
-    public void testLongValues() throws Exception
-    {
+    public void testLongValues() throws Exception {
         CBORFactorySizer f = cborFactorySizer();
         _verifyLong(f, 1L + Integer.MAX_VALUE);
         _verifyLong(f, -1L + Integer.MIN_VALUE);
     }
 
-    private void _verifyLong(CBORFactorySizer f, long value) throws Exception
-    {
+    private void _verifyLong(CBORFactorySizer f, long value) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         JsonGenerator gen = cborGeneratorSizer(f, out);
         gen.writeNumber(value);
@@ -106,9 +100,8 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         assertNull(p.nextToken());
         p.close();
     }
-    
-    public void testFloatValues() throws Exception
-    {
+
+    public void testFloatValues() throws Exception {
         // first, single-byte
         CBORFactorySizer f = cborFactorySizer();
         // single byte
@@ -116,7 +109,8 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         _verifyFloat(f, 20.5);
 
         // But then, oddity: 16-bit mini-float
-        // Examples from [https://en.wikipedia.org/wiki/Half_precision_floating-point_format]
+        // Examples from
+        // [https://en.wikipedia.org/wiki/Half_precision_floating-point_format]
         _verifyHalfFloat(f, 0, 0.0);
         _verifyHalfFloat(f, 0x3C00, 1.0);
         _verifyHalfFloat(f, 0xC000, -2.0);
@@ -127,8 +121,7 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         // ... can add more, but need bit looser comparison if so
     }
 
-    private void _verifyFloat(CBORFactorySizer f, double value) throws Exception
-    {
+    private void _verifyFloat(CBORFactorySizer f, double value) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         JsonGenerator gen = cborGeneratorSizer(f, out);
         gen.writeNumber((float) value);
@@ -136,39 +129,34 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         JsonParser p = cborParser(f, out.toByteArray());
         assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         if (NumberType.FLOAT != p.getNumberType()) {
-            fail("Expected `NumberType.FLOAT`, got "+p.getNumberType()+": "+p.getText());
+            fail("Expected `NumberType.FLOAT`, got " + p.getNumberType() + ": " + p.getText());
         }
         assertEquals(value, p.getDoubleValue());
         assertNull(p.nextToken());
         p.close();
     }
 
-    private void _verifyHalfFloat(JsonFactory f, int i16, double value) throws IOException
-    {
-        JsonParser p = f.createParser(new byte[] {
-                (byte) (CBORConstants.PREFIX_TYPE_MISC + 25),
-                (byte) (i16 >> 8), (byte) i16
-        });
+    private void _verifyHalfFloat(JsonFactory f, int i16, double value) throws IOException {
+        JsonParser p = f.createParser(
+                new byte[] { (byte) (CBORConstants.PREFIX_TYPE_MISC + 25), (byte) (i16 >> 8), (byte) i16 });
         assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertEquals(NumberType.FLOAT, p.getNumberType());
         assertEquals(value, p.getDoubleValue());
         assertNull(p.nextToken());
         p.close();
     }
-    
-    public void testSimpleArray() throws Exception
-    {
-        byte[] b = MAPPER.writeValueAsBytes(new int[] { 1, 2, 3, 4});
+
+    public void testSimpleArray() throws Exception {
+        byte[] b = MAPPER.writeValueAsBytes(new int[] { 1, 2, 3, 4 });
         int[] output = MAPPER.readValue(b, int[].class);
         assertEquals(4, output.length);
         for (int i = 1; i <= output.length; ++i) {
-            assertEquals(i, output[i-1]);
+            assertEquals(i, output[i - 1]);
         }
     }
 
-    public void testSimpleObject() throws Exception
-    {
-        Map<String,Object> input = new LinkedHashMap<String,Object>();
+    public void testSimpleObject() throws Exception {
+        Map<String, Object> input = new LinkedHashMap<String, Object>();
         input.put("a", 1);
         input.put("bar", "foo");
         final String NON_ASCII_NAME = "Y\\u00F6";
@@ -199,12 +187,12 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         assertEquals("", p.getCurrentName());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("", p.getText());
-        
+
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
         p.close();
-        
-        Map<?,?> output = MAPPER.readValue(b, Map.class);
+
+        Map<?, ?> output = MAPPER.readValue(b, Map.class);
         assertEquals(4, output.size());
         assertEquals(Integer.valueOf(1), output.get("a"));
         assertEquals("foo", output.get("bar"));
@@ -212,17 +200,15 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         assertEquals("", output.get(""));
     }
 
-    public void testMediumText() throws Exception
-    {
+    public void testMediumText() throws Exception {
         _testMedium(1100);
         _testMedium(1300);
         _testMedium(1900);
         _testMedium(2300);
         _testMedium(3900);
     }
-    
-    private void _testMedium(int len) throws Exception
-    {
+
+    private void _testMedium(int len) throws Exception {
         // First, use size that should fit in output buffer, but
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         CBORGeneratorSizer gen = cborGeneratorSizer(out);
@@ -234,7 +220,7 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
 
         // verify that it is indeed non-chunked still...
         assertEquals((byte) (CBORConstants.PREFIX_TYPE_TEXT + 25), b[0]);
-        
+
         JsonParser p = cborParser(b);
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals(MEDIUM, p.getText());
@@ -270,8 +256,7 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         assertEquals(22, p.getCurrentLocation().getByteOffset());
     }
 
-    public void testLongNonChunkedText() throws Exception
-    {
+    public void testLongNonChunkedText() throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         final String LONG = generateUnicodeString(37000);
@@ -296,33 +281,31 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         final int end = Math.min(LONG.length(), actual.length());
         for (int i = 0; i < end; ++i) {
             if (LONG.charAt(i) != actual.charAt(i)) {
-                fail("Character #"+i+" (of "+end+") differs; expected 0x"+Integer.toHexString(LONG.charAt(i))
-                        +" found 0x"+Integer.toHexString(actual.charAt(i)));
+                fail("Character #" + i + " (of " + end + ") differs; expected 0x" + Integer.toHexString(LONG.charAt(i))
+                        + " found 0x" + Integer.toHexString(actual.charAt(i)));
             }
         }
-        
+
         assertEquals(LONG.length(), actual.length());
-        
+
         assertEquals(LONG, p.getText());
         assertToken(JsonToken.END_ARRAY, p.nextToken());
         assertNull(p.nextToken());
         p.close();
     }
-    
-    public void testLongChunkedText() throws Exception
-    {
+
+    public void testLongChunkedText() throws Exception {
         // First, try with ASCII content
         StringBuilder sb = new StringBuilder(21000);
         for (int i = 0; i < 21000; ++i) {
             sb.append('Z');
         }
-        _testLongChunkedText(sb.toString());        
+        _testLongChunkedText(sb.toString());
         // Second, with actual variable byte-length Unicode
         _testLongChunkedText(generateUnicodeString(21000));
     }
-        
-    public void _testLongChunkedText(String input) throws Exception
-    {
+
+    public void _testLongChunkedText(String input) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         CBORGeneratorSizer gen = cborGeneratorSizer(out);
         gen.writeString(input);
@@ -331,13 +314,13 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         final int textByteCount = input.getBytes("UTF-8").length;
         final byte[] b = out.toByteArray();
         assertEquals((byte) (CBORConstants.PREFIX_TYPE_TEXT + 0x1F), b[0]);
-        assertEquals(CBORConstants.BYTE_BREAK, b[b.length-1]);
+        assertEquals(CBORConstants.BYTE_BREAK, b[b.length - 1]);
 
         // First, verify validity by scanning
         int i = 1;
         int total = 0;
 
-        for (int end = b.length-1; i < end; ) {
+        for (int end = b.length - 1; i < end;) {
             int type = b[i++] & 0xFF;
             int len = type - CBORConstants.PREFIX_TYPE_TEXT;
 
@@ -351,7 +334,7 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
             i += len;
             total += len;
         }
-        assertEquals(b.length-1, i);
+        assertEquals(b.length - 1, i);
         assertEquals(textByteCount, total);
 
         JsonParser p;
@@ -361,7 +344,7 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertNull(p.nextToken());
         p.close();
-        
+
         // and then with actual full parsing/access
         p = cborParser(new ByteArrayInputStream(b));
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
@@ -370,10 +353,11 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         assertEquals(input.length(), actual.length());
         if (!input.equals(actual)) {
             i = 0;
-            while (i < input.length() && input.charAt(i) == actual.charAt(i)) { ++i; }
-            fail("Strings differ at #"+i+" (length "+input.length()+"); expected 0x"
-                    +Integer.toHexString(input.charAt(i))+", got 0x"
-                    +Integer.toHexString(actual.charAt(i)));
+            while (i < input.length() && input.charAt(i) == actual.charAt(i)) {
+                ++i;
+            }
+            fail("Strings differ at #" + i + " (length " + input.length() + "); expected 0x"
+                    + Integer.toHexString(input.charAt(i)) + ", got 0x" + Integer.toHexString(actual.charAt(i)));
         }
         assertEquals(input, actual);
         p.close();
@@ -392,7 +376,10 @@ public class ParserSimpleTestSizer extends CBORTestBaseSizer
         assertEquals(JsonToken.START_OBJECT, parser.nextToken());
         assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
         assertEquals(JsonToken.VALUE_NUMBER_FLOAT, parser.nextToken());
-        assertEquals(NumberType.FLOAT, parser.getNumberType()); // fails with expected <FLOAT> but was <DOUBLE>
+        assertEquals(NumberType.FLOAT, parser.getNumberType()); // fails with
+                                                                // expected
+                                                                // <FLOAT> but
+                                                                // was <DOUBLE>
         assertEquals(JsonToken.END_OBJECT, parser.nextToken());
         parser.close();
     }

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/TestBiggerDataOnGeneratorSizer.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/TestBiggerDataOnGeneratorSizer.java
@@ -1,85 +1,18 @@
-package com.fasterxml.jackson.dataformat.cbor;
-
-import java.util.*;
+package com.fasterxml.jackson.dataformat.cbor.sizer;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.dataformat.cbor.TestBiggerData;
 
 /**
  * Bigger test to try to do smoke-testing of overall functionality,
  * using more sizable (500k of JSON, 200k of encoded data) dataset.
  * Should tease out at least some of boundary conditions.
  */
-public class TestBiggerData extends CBORTestBase
-{
-	public static class Citm
-	{
-		public Map<Integer,String> areaNames;
-		public Map<Integer,String> audienceSubCategoryNames;
-		public Map<Integer,String> blockNames;
-		public Map<Integer,String> seatCategoryNames;
-		public Map<Integer,String> subTopicNames;
-		public Map<Integer,String> subjectNames;
-		public Map<Integer,String> topicNames;
-		public Map<Integer,int[]> topicSubTopics;
-		public Map<String,String> venueNames;
-
-		public Map<Integer,Event> events;
-		public List<Performance> performances;
-	}
-
-	public static class Event
-	{
-		public int id;
-		public String name;
-		public String description;
-		public String subtitle;
-		public String logo;
-		public int subjectCode;
-		public int[] topicIds;
-		public LinkedHashSet<Integer> subTopicIds;
-	}
-
-	public static class Performance
-	{
-		public int id;
-		public int eventId;
-		public String name;
-		public String description;
-		public String logo;
-
-		public List<Price> prices;
-		public List<SeatCategory> seatCategories;
-
-		public long start;
-		public String seatMapImage;
-		public String venueCode;
-}
-
-	public static class Price {
-		public int amount;
-		public int audienceSubCategoryId;
-		public int seatCategoryId;
-	}
-
-	public static class SeatCategory {
-		public int seatCategoryId;
-		public List<Area> areas;
-	}
-
-	public static class Area {
-		public int areaId;
-		public int[] blockIds;
-	}
-
-    /*
-    /**********************************************************
-    /* Test methods
-    /**********************************************************
-     */
-
+public class TestBiggerDataOnGeneratorSizer extends TestBiggerData
+{	
 	final ObjectMapper MAPPER = new ObjectMapper();
 	
-	public void testReading() throws Exception
+	public void testReadingOnGeneratorSizer() throws Exception
 	{
 		Citm citm0 = MAPPER.readValue(getClass().getResourceAsStream("/data/citm_catalog.json"),
 				Citm.class);
@@ -108,8 +41,8 @@ public class TestBiggerData extends CBORTestBase
 		assertNotNull(citm.venueNames);
 		assertEquals(1, citm.venueNames.size());
 	}
-
-	public void testRoundTrip() throws Exception
+	
+	public void testRoundTripOnGeneratorSizer() throws Exception
 	{
 		Citm citm0 = MAPPER.readValue(getClass().getResourceAsStream("/data/citm_catalog.json"),
 				Citm.class);

--- a/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/TestBiggerDataOnGeneratorSizer.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/cbor/sizer/TestBiggerDataOnGeneratorSizer.java
@@ -4,69 +4,64 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.dataformat.cbor.TestBiggerData;
 
 /**
- * Bigger test to try to do smoke-testing of overall functionality,
- * using more sizable (500k of JSON, 200k of encoded data) dataset.
- * Should tease out at least some of boundary conditions.
+ * Bigger test to try to do smoke-testing of overall functionality, using more
+ * sizable (500k of JSON, 200k of encoded data) dataset. Should tease out at
+ * least some of boundary conditions.
  */
-public class TestBiggerDataOnGeneratorSizer extends TestBiggerData
-{	
-	final ObjectMapper MAPPER = new ObjectMapper();
-	
-	public void testReadingOnGeneratorSizer() throws Exception
-	{
-		Citm citm0 = MAPPER.readValue(getClass().getResourceAsStream("/data/citm_catalog.json"),
-				Citm.class);
+public class TestBiggerDataOnGeneratorSizer extends TestBiggerData {
+    final ObjectMapper MAPPER = new ObjectMapper();
 
-		ObjectMapper mapper = cborMapper();
-		byte[] cbor = mapper.writeValueAsBytes(citm0);
+    public void testReadingOnGeneratorSizer() throws Exception {
+        Citm citm0 = MAPPER.readValue(getClass().getResourceAsStream("/data/citm_catalog.json"), Citm.class);
 
-		Citm citm = mapper.readValue(cbor, Citm.class);
-		
-		assertNotNull(citm);
-		assertNotNull(citm.areaNames);
-		assertEquals(17, citm.areaNames.size());
-		assertNotNull(citm.events);
-		assertEquals(184, citm.events.size());
+        ObjectMapper mapper = cborMapper();
+        byte[] cbor = mapper.writeValueAsBytes(citm0);
 
-		assertNotNull(citm.seatCategoryNames);
-		assertEquals(64, citm.seatCategoryNames.size());
-		assertNotNull(citm.subTopicNames);
-		assertEquals(19, citm.subTopicNames.size());
-		assertNotNull(citm.subjectNames);
-		assertEquals(0, citm.subjectNames.size());
-		assertNotNull(citm.topicNames);
-		assertEquals(4, citm.topicNames.size());
-		assertNotNull(citm.topicSubTopics);
-		assertEquals(4, citm.topicSubTopics.size());
-		assertNotNull(citm.venueNames);
-		assertEquals(1, citm.venueNames.size());
-	}
-	
-	public void testRoundTripOnGeneratorSizer() throws Exception
-	{
-		Citm citm0 = MAPPER.readValue(getClass().getResourceAsStream("/data/citm_catalog.json"),
-				Citm.class);
-		ObjectMapper mapper = cborMapper();
-		byte[] cbor = mapper.writeValueAsBytes(citm0);
+        Citm citm = mapper.readValue(cbor, Citm.class);
 
-		Citm citm = mapper.readValue(cbor, Citm.class);
+        assertNotNull(citm);
+        assertNotNull(citm.areaNames);
+        assertEquals(17, citm.areaNames.size());
+        assertNotNull(citm.events);
+        assertEquals(184, citm.events.size());
 
-		byte[] smile1 = mapper.writeValueAsBytes(citm);
-		Citm citm2 = mapper.readValue(smile1, Citm.class);
-		byte[] smile2 = mapper.writeValueAsBytes(citm2);
+        assertNotNull(citm.seatCategoryNames);
+        assertEquals(64, citm.seatCategoryNames.size());
+        assertNotNull(citm.subTopicNames);
+        assertEquals(19, citm.subTopicNames.size());
+        assertNotNull(citm.subjectNames);
+        assertEquals(0, citm.subjectNames.size());
+        assertNotNull(citm.topicNames);
+        assertEquals(4, citm.topicNames.size());
+        assertNotNull(citm.topicSubTopics);
+        assertEquals(4, citm.topicSubTopics.size());
+        assertNotNull(citm.venueNames);
+        assertEquals(1, citm.venueNames.size());
+    }
 
-		assertEquals(smile1.length, smile2.length);
+    public void testRoundTripOnGeneratorSizer() throws Exception {
+        Citm citm0 = MAPPER.readValue(getClass().getResourceAsStream("/data/citm_catalog.json"), Citm.class);
+        ObjectMapper mapper = cborMapper();
+        byte[] cbor = mapper.writeValueAsBytes(citm0);
 
-		assertNotNull(citm.areaNames);
-		assertEquals(17, citm.areaNames.size());
-		assertNotNull(citm.events);
-		assertEquals(184, citm.events.size());
+        Citm citm = mapper.readValue(cbor, Citm.class);
 
-		assertEquals(citm.seatCategoryNames.size(), citm2.seatCategoryNames.size());
-		assertEquals(citm.subTopicNames.size(), citm2.subTopicNames.size());
-		assertEquals(citm.subjectNames.size(), citm2.subjectNames.size());
-		assertEquals(citm.topicNames.size(), citm2.topicNames.size());
-		assertEquals(citm.topicSubTopics.size(), citm2.topicSubTopics.size());
-		assertEquals(citm.venueNames.size(), citm2.venueNames.size());
-	}
+        byte[] smile1 = mapper.writeValueAsBytes(citm);
+        Citm citm2 = mapper.readValue(smile1, Citm.class);
+        byte[] smile2 = mapper.writeValueAsBytes(citm2);
+
+        assertEquals(smile1.length, smile2.length);
+
+        assertNotNull(citm.areaNames);
+        assertEquals(17, citm.areaNames.size());
+        assertNotNull(citm.events);
+        assertEquals(184, citm.events.size());
+
+        assertEquals(citm.seatCategoryNames.size(), citm2.seatCategoryNames.size());
+        assertEquals(citm.subTopicNames.size(), citm2.subTopicNames.size());
+        assertEquals(citm.subjectNames.size(), citm2.subjectNames.size());
+        assertEquals(citm.topicNames.size(), citm2.topicNames.size());
+        assertEquals(citm.topicSubTopics.size(), citm2.topicSubTopics.size());
+        assertEquals(citm.venueNames.size(), citm2.venueNames.size());
+    }
 }


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/jackson-dev/QDkhQBD3PaA

Hi Tatu

According to our discussion, this is our changes to the CBOR dataformat that allows the usage of bounded arrays and objects. No changes to the API has been done. The implementation in CBORGenerator has slightly changed for:
• writeStartArray()
• writeStartArray(int size)
• writeEndArray()
• writeStartObject()
• writeStartObject(Object forValue)
• writeEndtObject ()

We added:
• writeStartObject (int size) (new method)
• Stack<Integer> _arraySize
• Stack<Integer> _objectSize

The class CBORGeneratorSizer decorates CBORGenerator permits the queuing of writing commands defined in CBORCommands. We stack the commands until the end of objects or arrays. 

We  created another Factory to avoid impacting CBORFactory. Also we want both functionality available since our approach can have some drawbacks on memory usage.

Thanks,
